### PR TITLE
add code coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,9 +39,16 @@ jobs:
         echo "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}" >> $GITHUB_ENV
         echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> $GITHUB_ENV
 
-    - name: Run tests
+    - name: Run tests with coverage
       run: |
-        poetry run pytest tests/
+        poetry run pytest --cov=src/sql_testing_library --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        fail_ci_if_error: false
 
     - name: Clean up credentials
       run: |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A Python library for testing SQL queries with mock data injection across Athena, BigQuery, and Redshift.
 
 [![Tests](https://github.com/gurmeetsaran/sqltesting/actions/workflows/tests.yaml/badge.svg)](https://github.com/gurmeetsaran/sqltesting/actions/workflows/tests.yaml)
+[![codecov](https://codecov.io/gh/gurmeetsaran/sqltesting/branch/master/graph/badge.svg)](https://codecov.io/gh/gurmeetsaran/sqltesting)
 ## Features
 
 - **Multi-Database Support**: Test SQL across BigQuery, Athena, and Redshift

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -48,6 +48,47 @@ To run static type checking with Mypy:
 poetry run mypy src
 ```
 
+## Code Coverage
+
+The project uses [pytest-cov](https://pytest-cov.readthedocs.io/) to measure code coverage. This helps ensure that tests exercise as much of the codebase as possible.
+
+### Local Coverage
+
+To run tests with code coverage locally:
+
+```bash
+# Using the script
+./scripts/coverage.sh
+
+# Or directly
+poetry run pytest
+```
+
+The coverage configuration is defined in `pyproject.toml` under the `[tool.pytest.ini_options]` section. The current setup:
+
+- Measures coverage for the `src/sql_testing_library` directory
+- Generates a terminal report with missing lines highlighted
+- Creates an XML report at `coverage.xml` (useful for CI systems)
+- Creates an HTML report in the `htmlcov` directory
+
+To view the HTML coverage report, open `htmlcov/index.html` in a browser after running the tests.
+
+### CI/CD Coverage
+
+The project is also configured to publish code coverage metrics to [Codecov](https://codecov.io/) as part of the CI pipeline. This provides:
+
+1. A public dashboard showing code coverage trends over time
+2. A badge in the README showing current coverage percentage
+3. Coverage feedback on pull requests
+4. Detailed reports on which parts of the code lack test coverage
+
+The GitHub Actions workflow automatically:
+- Runs tests with coverage enabled
+- Generates an XML coverage report
+- Uploads the report to Codecov
+
+The Codecov configuration is stored in `codecov.yml` at the root of the repository.
+
 ## Configuration
 
 ### Ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,9 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+addopts = "--cov=src/sql_testing_library --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:htmlcov"
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"


### PR DESCRIPTION
 1. Created a codecov.yml configuration file at the root of the repository:
    - Configured coverage thresholds and targets
    - Set up project path filters
    - Configured codecov comment behavior
  2. Updated the GitHub Actions workflow (tests.yaml):
    - Modified the test step to generate an XML coverage report
    - Added a step to upload the coverage report to Codecov using the official action
  3. Added a Codecov badge to the README.md:
    - Placed it next to the existing Tests badge
    - Linked it to the project's Codecov dashboard
  4. Updated the documentation:
    - Added a section about CI/CD coverage in the docs/linting.md file
    - Described the benefits of using Codecov



Fixes #7 