### PR TITLE
fix: use personal access token for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,4 +62,4 @@ jobs:
           draft: false
           prerelease: ${{ startsWith(steps.version.outputs.version, '0.') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
  - Update release workflow to use PERSONAL_ACCESS_TOKEN instead of GITHUB_TOKEN
  - Enables automated GitHub release creation with proper permissions
  - Completes end-to-end automated versioning and release pipeline