### PR TITLE
fix: resolve Python version compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ commitizen = ">=3.0.0"
 sql_testing = "sql_testing_library.pytest_plugin"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
  - Update mypy configuration from Python 3.8 to 3.9 to match project requirements
  - Replace parenthesized context manager syntax with backslash continuation for Python 3.9 compatibility
  - Fixes PyCharm syntax error in test_core_extra.py while maintaining functionality