### PR TITLE
fix: add explicit type casting for NULL values in Redshift adapter

### DIFF
--- a/src/sql_testing_library/adapters/redshift.py
+++ b/src/sql_testing_library/adapters/redshift.py
@@ -123,7 +123,21 @@ class RedshiftAdapter(DatabaseAdapter):
     def format_value_for_cte(self, value: Any, column_type: type) -> str:
         """Format value for Redshift CTE VALUES clause."""
         if value is None:
-            return "NULL"
+            # Cast NULL values to appropriate types for Redshift
+            if column_type == Decimal:
+                return "NULL::DECIMAL(38,9)"
+            elif column_type is int:
+                return "NULL::BIGINT"
+            elif column_type is float:
+                return "NULL::DOUBLE PRECISION"
+            elif column_type is bool:
+                return "NULL::BOOLEAN"
+            elif column_type is date:
+                return "NULL::DATE"
+            elif column_type == datetime:
+                return "NULL::TIMESTAMP"
+            else:
+                return "NULL::VARCHAR(1024)"
         elif column_type is str:
             # Escape single quotes for SQL
             escaped_value = str(value).replace("'", "''")

--- a/tests/integration/test_redshift_integration.py
+++ b/tests/integration/test_redshift_integration.py
@@ -63,8 +63,8 @@ class OrderSummaryResult(BaseModel):
     customer_id: int
     customer_name: str
     order_count: int
-    total_spent: Decimal
-    avg_order_value: Decimal
+    total_spent: Optional[Decimal]
+    avg_order_value: Optional[Decimal]
 
 
 class ProductAnalyticsResult(BaseModel):
@@ -200,7 +200,6 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert results[0].customer_id == 1
         assert results[0].name == "Alice Johnson"
 
-    @pytest.mark.skip(reason="Skipping customer order join test")
     def test_customer_order_join(self):
         """Test joining customers with orders data."""
 
@@ -384,7 +383,6 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert hasattr(results[0], "order_count")
         assert results[0].order_count >= 0
 
-    @pytest.mark.skip(reason="Skipping null handling test")
     def test_null_handling(self):
         """Test proper handling of NULL values."""
 
@@ -429,7 +427,6 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert all(hasattr(result, "total_amount") for result in results)
 
-    @pytest.mark.skip(reason="Skipping string function test")
     def test_string_functions(self):
         """Test string manipulation functions."""
 
@@ -512,7 +509,6 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert results[0].customer_id == 1
 
-    @pytest.mark.skip(reason="Skipping window function test")
     def test_window_functions(self):
         """Test window functions and ranking."""
 
@@ -593,7 +589,6 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "avg_price") for result in results)
         assert all(result.product_count > 0 for result in results)
 
-    @pytest.mark.skip(reason="Skipping subquery test")
     def test_subquery_operations(self):
         """Test subquery operations and EXISTS clauses."""
 

--- a/tests/test_redshift_adapter.py
+++ b/tests/test_redshift_adapter.py
@@ -193,8 +193,14 @@ class TestRedshiftAdapter(unittest.TestCase):
             "TIMESTAMP '2023-01-15T10:30:45'",
         )
 
-        # Test None
-        self.assertEqual(adapter.format_value_for_cte(None, str), "NULL")
+        # Test None with type casting
+        self.assertEqual(adapter.format_value_for_cte(None, str), "NULL::VARCHAR(1024)")
+        self.assertEqual(adapter.format_value_for_cte(None, Decimal), "NULL::DECIMAL(38,9)")
+        self.assertEqual(adapter.format_value_for_cte(None, int), "NULL::BIGINT")
+        self.assertEqual(adapter.format_value_for_cte(None, float), "NULL::DOUBLE PRECISION")
+        self.assertEqual(adapter.format_value_for_cte(None, bool), "NULL::BOOLEAN")
+        self.assertEqual(adapter.format_value_for_cte(None, date), "NULL::DATE")
+        self.assertEqual(adapter.format_value_for_cte(None, datetime), "NULL::TIMESTAMP")
 
     def test_create_temp_table(self, mock_psycopg2_connect):
         """Test temp table creation."""


### PR DESCRIPTION
  - Cast NULL values to appropriate Redshift types in format_value_for_cte method
  - Resolves "cannot convert type unknown to numeric" error when using NULL decimals with COALESCE
  - Add comprehensive type casting: DECIMAL(38,9), BIGINT, DOUBLE PRECISION, BOOLEAN, DATE, TIMESTAMP, VARCHAR(1024)
  - Update unit tests to validate new typed NULL behavior
  - Remove pytest.mark.skip decorators from previously failing integration tests