### PR TITLE
fix: update commitizen arguments in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.version_type }}" = "auto" ]; then
             echo "🤖 Auto-determining version bump from conventional commits..."
-            poetry run cz bump --changelog --yes --changelog-increment-filename body.md
+            poetry run cz bump --changelog --yes -- --changelog-increment-filename body.md
           else
             echo "📌 Manual version bump: ${{ github.event.inputs.version_type }}"
-            poetry run cz bump --increment ${{ github.event.inputs.version_type }} --changelog --yes --changelog-increment-filename body.md
+            poetry run cz bump --increment ${{ github.event.inputs.version_type }} --changelog --yes -- --changelog-increment-filename body.md
           fi
 
       - name: Get new version


### PR DESCRIPTION
  Add -- separator before --changelog-increment-filename argument to fix
  commitizen command execution in GitHub Actions workflow.