### PR TITLE
feat: parametrize integration tests and standardize SQL across adapters

### DIFF
--- a/.github/ATHENA_CICD_SETUP.md
+++ b/.github/ATHENA_CICD_SETUP.md
@@ -67,7 +67,10 @@ Create a dedicated IAM user for GitHub Actions with minimal permissions:
                 "glue:GetDatabase",
                 "glue:GetTable",
                 "glue:GetTables",
-                "glue:GetPartitions"
+                "glue:GetPartitions",
+                "glue:CreateTable",
+                "glue:DeleteTable",
+                "glue:UpdateTable"
             ],
             "Resource": "*"
         }
@@ -226,3 +229,34 @@ strategy:
 ```
 
 This allows running all adapter tests in parallel while maintaining cost control.
+
+## 🗃️ Physical Tables Support
+
+The SQL Testing Library supports two execution modes for Athena:
+
+### CTE Mode (Default)
+- Mock data injected as Common Table Expressions
+- No additional AWS permissions required
+- Works with the basic IAM policy above
+- Suitable for most test scenarios
+
+### Physical Tables Mode
+- Creates temporary external tables in AWS Glue Data Catalog
+- **Requires additional Glue permissions** (included in IAM policy above):
+  - `glue:CreateTable` - Create temporary test tables
+  - `glue:DeleteTable` - Clean up test tables after tests
+  - `glue:UpdateTable` - Modify table metadata if needed
+
+### Why Physical Tables?
+Physical tables are automatically used when:
+- CTE queries exceed Athena's 256KB query size limit
+- Explicitly requested via `use_physical_tables=True` parameter
+- Testing complex scenarios that require persistent table structures
+
+### Troubleshooting Physical Tables
+If you see errors like:
+```
+User: arn:aws:iam::xxx:user/github-actions is not authorized to perform: glue:CreateTable
+```
+
+**Solution**: Ensure your IAM user has all Glue permissions listed in the IAM policy above. The `glue:CreateTable`, `glue:DeleteTable`, and `glue:UpdateTable` permissions are essential for physical table creation and cleanup.

--- a/src/sql_testing_library/_adapters/trino.py
+++ b/src/sql_testing_library/_adapters/trino.py
@@ -201,12 +201,20 @@ class TrinoAdapter(DatabaseAdapter):
             columns_sql = ",\n  ".join(column_defs)
 
             # Create an empty table with the correct schema
-            return f"""
-            CREATE TABLE {qualified_table} (
-              {columns_sql}
-            )
-            WITH (format = 'ORC')
-            """
+            # Memory catalog doesn't support table properties like format
+            if self.catalog == "memory":
+                return f"""
+                CREATE TABLE {qualified_table} (
+                  {columns_sql}
+                )
+                """
+            else:
+                return f"""
+                CREATE TABLE {qualified_table} (
+                  {columns_sql}
+                )
+                WITH (format = 'ORC')
+                """
         else:
             # For tables with data, use CTAS with a VALUES clause
             # Build a SELECT statement with literal values for the first row
@@ -236,8 +244,15 @@ class TrinoAdapter(DatabaseAdapter):
                 select_sql += f"\nUNION ALL SELECT {', '.join(row_values)}"
 
             # Create the CTAS statement
-            return f"""
-            CREATE TABLE {qualified_table}
-            WITH (format = 'ORC')
-            AS {select_sql}
-            """
+            # Memory catalog doesn't support table properties like format
+            if self.catalog == "memory":
+                return f"""
+                CREATE TABLE {qualified_table}
+                AS {select_sql}
+                """
+            else:
+                return f"""
+                CREATE TABLE {qualified_table}
+                WITH (format = 'ORC')
+                AS {select_sql}
+                """

--- a/tests/integration/test_redshift_integration.py
+++ b/tests/integration/test_redshift_integration.py
@@ -1,6 +1,5 @@
 """Integration tests for Redshift adapter with pytest configuration."""
 
-import unittest
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -115,10 +114,13 @@ class ProductsMockTable(BaseMockTable):
 
 @pytest.mark.integration
 @pytest.mark.redshift
-class TestRedshiftIntegration(unittest.TestCase):
+@pytest.mark.parametrize(
+    "use_physical_tables", [False, True], ids=["cte_mode", "physical_tables_mode"]
+)
+class TestRedshiftIntegration:
     """Integration tests for Redshift adapter functionality."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up test data for all integration tests."""
         self.customers_data = [
             Customer(
@@ -150,7 +152,7 @@ class TestRedshiftIntegration(unittest.TestCase):
             Product(5, "Old Monitor", "Electronics", Decimal("150.00"), False),
         ]
 
-    def test_simple_customer_query(self):
+    def test_simple_customer_query(self, use_physical_tables):
         """Test basic customer data retrieval."""
 
         @sql_test(
@@ -192,6 +194,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     WHERE customer_id = 1
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -200,7 +203,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert results[0].customer_id == 1
         assert results[0].name == "Alice Johnson"
 
-    def test_customer_order_join(self):
+    def test_customer_order_join(self, use_physical_tables):
         """Test joining customers with orders data."""
 
         @sql_test(
@@ -227,6 +230,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY total_amount DESC
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -235,7 +239,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert all(hasattr(result, "total_orders") for result in results)
 
-    def test_order_summary_analytics(self):
+    def test_order_summary_analytics(self, use_physical_tables):
         """Test order summary analytics with aggregations."""
 
         @sql_test(
@@ -305,6 +309,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY total_spent DESC
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -314,7 +319,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "order_count") for result in results)
         assert all(result.order_count >= 1 for result in results)
 
-    def test_product_category_analytics(self):
+    def test_product_category_analytics(self, use_physical_tables):
         """Test product analytics by category."""
 
         @sql_test(
@@ -345,6 +350,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY total_revenue DESC
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -354,7 +360,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "product_count") for result in results)
         assert all(result.product_count > 0 for result in results)
 
-    def test_complex_date_filtering(self):
+    def test_complex_date_filtering(self, use_physical_tables):
         """Test complex date-based filtering and aggregations."""
 
         @sql_test(
@@ -374,6 +380,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                       AND status IN ('completed', 'pending')
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -383,7 +390,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert hasattr(results[0], "order_count")
         assert results[0].order_count >= 0
 
-    def test_null_handling(self):
+    def test_null_handling(self, use_physical_tables):
         """Test proper handling of NULL values."""
 
         @sql_test(
@@ -419,6 +426,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY customer_id
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -427,7 +435,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert all(hasattr(result, "total_amount") for result in results)
 
-    def test_string_functions(self):
+    def test_string_functions(self, use_physical_tables):
         """Test string manipulation functions."""
 
         @sql_test(
@@ -449,6 +457,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY customer_id
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -458,7 +467,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "name") for result in results)
         assert all(len(result.name) > 0 for result in results)
 
-    def test_boolean_operations(self):
+    def test_boolean_operations(self, use_physical_tables):
         """Test boolean field operations and filtering."""
 
         @sql_test(
@@ -501,6 +510,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY customer_id
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -509,7 +519,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert results[0].customer_id == 1
 
-    def test_window_functions(self):
+    def test_window_functions(self, use_physical_tables):
         """Test window functions and ranking."""
 
         @sql_test(
@@ -535,6 +545,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY total_spent DESC NULLS LAST
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -544,7 +555,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_name") for result in results)
         assert all(hasattr(result, "order_count") for result in results)
 
-    def test_case_statements(self):
+    def test_case_statements(self, use_physical_tables):
         """Test CASE statements and conditional logic."""
 
         @sql_test(
@@ -580,6 +591,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY avg_price DESC
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -589,7 +601,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "avg_price") for result in results)
         assert all(result.product_count > 0 for result in results)
 
-    def test_subquery_operations(self):
+    def test_subquery_operations(self, use_physical_tables):
         """Test subquery operations and EXISTS clauses."""
 
         @sql_test(
@@ -618,6 +630,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                     ORDER BY customer_id
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -627,7 +640,7 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert all(hasattr(result, "name") for result in results)
         assert all(hasattr(result, "email") for result in results)
 
-    def test_date_functions(self):
+    def test_date_functions(self, use_physical_tables):
         """Test date extraction and manipulation functions."""
 
         @sql_test(
@@ -661,6 +674,7 @@ class TestRedshiftIntegration(unittest.TestCase):
                       AND status = 'completed'
                 """,
                 execution_database="sqltesting_db",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -669,7 +683,3 @@ class TestRedshiftIntegration(unittest.TestCase):
         assert hasattr(results[0], "total_revenue")
         assert hasattr(results[0], "order_count")
         assert results[0].order_count >= 0
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/integration/test_trino_integration.py
+++ b/tests/integration/test_trino_integration.py
@@ -1,6 +1,5 @@
 """Integration tests for Trino adapter with pytest configuration."""
 
-import unittest
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -108,10 +107,13 @@ class ProductsMockTable(BaseMockTable):
 # Test data that will be reused across multiple tests
 @pytest.mark.integration
 @pytest.mark.trino
-class TestTrinoIntegration(unittest.TestCase):
+@pytest.mark.parametrize(
+    "use_physical_tables", [False, True], ids=["cte_mode", "physical_tables_mode"]
+)
+class TestTrinoIntegration:
     """Integration tests for Trino adapter using real database connections."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up test data for integration tests."""
         self.customers_data = [
             Customer(
@@ -142,7 +144,7 @@ class TestTrinoIntegration(unittest.TestCase):
             Product(5, "Old Monitor", "Electronics", Decimal("150.00"), False),
         ]
 
-    def test_simple_customer_query(self):
+    def test_simple_customer_query(self, use_physical_tables):
         """Test basic customer data retrieval."""
 
         @sql_test(
@@ -183,6 +185,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     FROM customers WHERE customer_id = 1
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -191,7 +194,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert results[0].customer_id == 1
         assert results[0].name == "Alice Johnson"
 
-    def test_customer_order_join(self):
+    def test_customer_order_join(self, use_physical_tables):
         """Test joining customers with orders data."""
 
         @sql_test(
@@ -218,6 +221,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY total_spent DESC
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -226,7 +230,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert all(hasattr(result, "order_count") for result in results)
 
-    def test_date_functions(self):
+    def test_date_functions(self, use_physical_tables):
         """Test date functions and filtering."""
 
         @sql_test(
@@ -248,6 +252,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY signup_date DESC
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -255,7 +260,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert len(results) >= 1
         assert all(hasattr(result, "customer_id") for result in results)
 
-    def test_complex_date_filtering(self):
+    def test_complex_date_filtering(self, use_physical_tables):
         """Test complex date operations and filtering."""
 
         @sql_test(
@@ -277,6 +282,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     AND status IN ('completed', 'pending')
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -286,7 +292,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert hasattr(results[0], "order_count")
         assert results[0].order_count >= 0
 
-    def test_null_handling(self):
+    def test_null_handling(self, use_physical_tables):
         """Test proper handling of NULL values."""
 
         @sql_test(
@@ -322,6 +328,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY customer_id
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -330,7 +337,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert all(hasattr(result, "total_amount") for result in results)
 
-    def test_string_functions(self):
+    def test_string_functions(self, use_physical_tables):
         """Test string manipulation functions."""
 
         @sql_test(
@@ -352,6 +359,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY name
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -359,7 +367,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert len(results) >= 1
         assert all(hasattr(result, "customer_id") for result in results)
 
-    def test_aggregation_functions(self):
+    def test_aggregation_functions(self, use_physical_tables):
         """Test aggregation and grouping operations."""
 
         @sql_test(
@@ -381,6 +389,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY avg_price DESC
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -389,7 +398,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert all(hasattr(result, "category") for result in results)
         assert all(hasattr(result, "avg_price") for result in results)
 
-    def test_boolean_operations(self):
+    def test_boolean_operations(self, use_physical_tables):
         """Test boolean logic and conditions."""
 
         @sql_test(
@@ -412,6 +421,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY lifetime_value DESC
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -420,7 +430,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert all(hasattr(result, "customer_id") for result in results)
         assert results[0].customer_id == 3
 
-    def test_window_functions(self):
+    def test_window_functions(self, use_physical_tables):
         """Test window functions and ranking."""
 
         @sql_test(
@@ -456,6 +466,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY total_spent DESC
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -463,7 +474,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert len(results) >= 1
         assert all(hasattr(result, "customer_id") for result in results)
 
-    def test_case_statements(self):
+    def test_case_statements(self, use_physical_tables):
         """Test CASE statements and conditional logic."""
 
         @sql_test(
@@ -492,6 +503,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY avg_price DESC
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test
@@ -501,7 +513,7 @@ class TestTrinoIntegration(unittest.TestCase):
         assert all(hasattr(result, "avg_price") for result in results)
         assert all(result.product_count > 0 for result in results)
 
-    def test_subquery_operations(self):
+    def test_subquery_operations(self, use_physical_tables):
         """Test subquery operations and EXISTS clauses."""
 
         @sql_test(
@@ -531,6 +543,7 @@ class TestTrinoIntegration(unittest.TestCase):
                     ORDER BY c.customer_id
                 """,
                 execution_database="memory",
+                use_physical_tables=use_physical_tables,
             )
 
         # Execute the test

--- a/tests/test_athena_adapter.py
+++ b/tests/test_athena_adapter.py
@@ -144,11 +144,11 @@ class TestAthenaAdapter(unittest.TestCase):
         test_datetime = datetime(2023, 1, 15, 10, 30, 45)
         self.assertEqual(
             adapter.format_value_for_cte(test_datetime, datetime),
-            "TIMESTAMP '2023-01-15 10:30:45'",
+            "TIMESTAMP '2023-01-15 10:30:45.000'",
         )
 
         # Test None
-        self.assertEqual(adapter.format_value_for_cte(None, str), "NULL")
+        self.assertEqual(adapter.format_value_for_cte(None, str), "CAST(NULL AS VARCHAR)")
 
     def test_create_temp_table(self, mock_boto3_client):
         """Test temp table creation."""

--- a/tests/test_redshift_adapter.py
+++ b/tests/test_redshift_adapter.py
@@ -194,7 +194,7 @@ class TestRedshiftAdapter(unittest.TestCase):
         )
 
         # Test None with type casting
-        self.assertEqual(adapter.format_value_for_cte(None, str), "NULL::VARCHAR(1024)")
+        self.assertEqual(adapter.format_value_for_cte(None, str), "NULL::VARCHAR")
         self.assertEqual(adapter.format_value_for_cte(None, Decimal), "NULL::DECIMAL(38,9)")
         self.assertEqual(adapter.format_value_for_cte(None, int), "NULL::BIGINT")
         self.assertEqual(adapter.format_value_for_cte(None, float), "NULL::DOUBLE PRECISION")
@@ -248,8 +248,8 @@ class TestRedshiftAdapter(unittest.TestCase):
         with mock.patch("time.time", return_value=1234567890.123):
             table_name = adapter.create_temp_table(mock_table)
 
-        # Check table name format (schema.table)
-        self.assertEqual(table_name, "public.temp_users_1234567890123")
+        # Check table name format (just table name for temp tables)
+        self.assertEqual(table_name, "temp_users_1234567890123")
 
         # Check execute_query calls - only one call for CTAS
         self.assertEqual(mock_cursor.execute.call_count, 1)

--- a/tests/test_snowflake_adapter.py
+++ b/tests/test_snowflake_adapter.py
@@ -199,7 +199,7 @@ class TestSnowflakeAdapter(unittest.TestCase):
         with mock.patch("time.time", return_value=1234567890.123):
             table_name = adapter.create_temp_table(mock_table)
 
-        self.assertEqual(table_name, "test_db.test_schema.TEMP_users_1234567890123")
+        self.assertEqual(table_name, "test_schema.TEMP_users_1234567890123")
 
         # Check that execute_query was called with CTAS
         mock_cursor.execute.assert_called_once()

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -101,7 +101,7 @@ class TestFormatSQLValue:
         from decimal import Decimal
 
         # Redshift requires explicit type casting for NULL values
-        assert format_sql_value(None, str, "redshift") == "NULL::VARCHAR(1024)"
+        assert format_sql_value(None, str, "redshift") == "NULL::VARCHAR"
         assert format_sql_value(None, int, "redshift") == "NULL::BIGINT"
         assert format_sql_value(None, float, "redshift") == "NULL::DOUBLE PRECISION"
         assert format_sql_value(None, bool, "redshift") == "NULL::BOOLEAN"
@@ -151,10 +151,10 @@ class TestFormatSQLValue:
 
         # Athena and Trino use space separator (don't like 'T')
         result_athena = format_sql_value(test_datetime, datetime, "athena")
-        assert result_athena == "TIMESTAMP '2023-12-25 15:30:45'"
+        assert result_athena == "TIMESTAMP '2023-12-25 15:30:45.000'"
 
         result_trino = format_sql_value(test_datetime, datetime, "trino")
-        assert result_trino == "TIMESTAMP '2023-12-25 15:30:45'"
+        assert result_trino == "TIMESTAMP '2023-12-25 15:30:45.000'"
 
         # Standard uses ISO format
         result_std = format_sql_value(test_datetime, datetime, "standard")

--- a/tests/test_trino_adapter.py
+++ b/tests/test_trino_adapter.py
@@ -186,17 +186,17 @@ class TestTrinoAdapter(unittest.TestCase):
         test_datetime = datetime(2023, 1, 15, 10, 30, 45)
         self.assertEqual(
             adapter.format_value_for_cte(test_datetime, datetime),
-            "TIMESTAMP '2023-01-15 10:30:45'",
+            "TIMESTAMP '2023-01-15 10:30:45.000'",
         )
 
-        # Test None (unified approach uses simple NULL for most dialects)
-        self.assertEqual(adapter.format_value_for_cte(None, str), "NULL")
-        self.assertEqual(adapter.format_value_for_cte(None, Decimal), "NULL")
-        self.assertEqual(adapter.format_value_for_cte(None, int), "NULL")
-        self.assertEqual(adapter.format_value_for_cte(None, float), "NULL")
-        self.assertEqual(adapter.format_value_for_cte(None, bool), "NULL")
-        self.assertEqual(adapter.format_value_for_cte(None, date), "NULL")
-        self.assertEqual(adapter.format_value_for_cte(None, datetime), "NULL")
+        # Test None (Trino uses CAST for NULL values)
+        self.assertEqual(adapter.format_value_for_cte(None, str), "CAST(NULL AS VARCHAR)")
+        self.assertEqual(adapter.format_value_for_cte(None, Decimal), "CAST(NULL AS DECIMAL(38,9))")
+        self.assertEqual(adapter.format_value_for_cte(None, int), "CAST(NULL AS BIGINT)")
+        self.assertEqual(adapter.format_value_for_cte(None, float), "CAST(NULL AS DOUBLE)")
+        self.assertEqual(adapter.format_value_for_cte(None, bool), "CAST(NULL AS BOOLEAN)")
+        self.assertEqual(adapter.format_value_for_cte(None, date), "CAST(NULL AS DATE)")
+        self.assertEqual(adapter.format_value_for_cte(None, datetime), "CAST(NULL AS TIMESTAMP)")
 
     def test_create_temp_table(self, mock_trino_connect):
         """Test temp table creation."""


### PR DESCRIPTION
  Major refactoring to parametrize integration tests for both CTE and Physical Tables
  modes, fix database-specific SQL issues, and optimize code consistency across all
  database adapters.

  ### Integration Test Parametrization
  - Convert integration tests from unittest.TestCase to pytest with class-level parametrization
  - Add @pytest.mark.parametrize for use_physical_tables=[False, True] across all databases
  - Separate Snowflake tests with CTE mode only due to environment limitations
  - Comprehensive primitive type tests across all adapters and execution modes

  ### Database Adapter Fixes
  - **Athena**: Fix identifier quoting, timestamp precision, NULL type casting, S3 paths
  - **Trino**: Fix memory catalog table properties, remove unsupported format options
  - **Redshift**: Fix temporary table schema qualification issues
  - **Snowflake**: Improve error handling and table cleanup procedures
  - **BigQuery**: Address decimal precision differences between execution modes

  ### SQL Utils Optimization
  - Standardize VARCHAR usage: remove size specifications (VARCHAR(65535), VARCHAR(1024))
  - Merge duplicate Athena/Trino NULL casting logic to reduce code duplication
  - All databases now use consistent VARCHAR without size constraints
  - Unify string escaping across database dialects

  ### Documentation Updates
  - Comprehensive README updates explaining CTE vs Physical Tables execution modes
  - Detailed cleanup behavior documentation for each database
  - FAQ section covering S3 cleanup for Athena, table lifecycle management
  - Updated execution mode examples and best practices