### PR TITLE
feat!: rename execution_database to default_namespace and standardize database context handling

### DIFF
--- a/tests/integration/test_bigquery_integration.py
+++ b/tests/integration/test_bigquery_integration.py
@@ -1,6 +1,5 @@
 """Integration tests for BigQuery adapter with pytest configuration."""
 
-import os
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -118,9 +117,7 @@ class UsersMockTable(BaseMockTable):
     """Mock table for user data."""
 
     def get_database_name(self) -> str:
-        project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-        database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
-        return f"{project_id}.{database}"
+        return "test-project.test_dataset"
 
     def get_table_name(self) -> str:
         return "users"
@@ -130,9 +127,7 @@ class OrdersMockTable(BaseMockTable):
     """Mock table for order data."""
 
     def get_database_name(self) -> str:
-        project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-        database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
-        return f"{project_id}.{database}"
+        return "test-project.test_dataset"
 
     def get_table_name(self) -> str:
         return "orders"
@@ -184,8 +179,8 @@ class TestBigQueryIntegration:
             result_class=User,
         )
         def query_premium_users():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -195,7 +190,7 @@ class TestBigQueryIntegration:
                     WHERE is_premium = TRUE
                     ORDER BY lifetime_value DESC
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -262,8 +257,8 @@ class TestBigQueryIntegration:
             result_class=UserOrderSummary,
         )
         def query_user_order_summary():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -278,7 +273,7 @@ class TestBigQueryIntegration:
                     GROUP BY u.user_id, u.name
                     ORDER BY u.user_id
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -311,8 +306,8 @@ class TestBigQueryIntegration:
             result_class=MonthlyRevenue,
         )
         def query_monthly_revenue():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -323,7 +318,7 @@ class TestBigQueryIntegration:
                     GROUP BY EXTRACT(MONTH FROM order_date)
                     ORDER BY month
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -394,8 +389,8 @@ class TestBigQueryIntegration:
             result_class=UserAnalyticsResult,
         )
         def query_user_analytics():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     WITH user_metrics AS (
@@ -430,7 +425,7 @@ class TestBigQueryIntegration:
                     FROM user_metrics
                     ORDER BY spending_rank
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -475,8 +470,8 @@ class TestBigQueryIntegration:
             result_class=NullHandlingResult,
         )
         def query_null_handling():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -495,7 +490,7 @@ class TestBigQueryIntegration:
                     FROM {project_id}.{database}.users
                     ORDER BY user_id
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -528,8 +523,8 @@ class TestBigQueryIntegration:
             result_class=TypeTestResult,
         )
         def query_type_conversion():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -542,7 +537,7 @@ class TestBigQueryIntegration:
                     JOIN {project_id}.{database}.orders o
                         ON u.user_id = o.user_id
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -574,8 +569,8 @@ class TestBigQueryIntegration:
             result_class=UserOrderSummary,
         )
         def query_empty_results():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -586,7 +581,7 @@ class TestBigQueryIntegration:
                     FROM {project_id}.{database}.users
                     WHERE user_id = 999  -- No matching user
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -608,8 +603,8 @@ class TestBigQueryIntegration:
             result_class=UserOrderSummary,
         )
         def query_missing_table():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT u.user_id, u.name, COUNT(o.order_id) as total_orders
@@ -618,7 +613,7 @@ class TestBigQueryIntegration:
                         ON u.user_id = o.user_id
                     GROUP BY u.user_id, u.name
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -637,8 +632,8 @@ class TestBigQueryIntegration:
             result_class=UserOrderSummary,
         )
         def query_single_user():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -649,7 +644,7 @@ class TestBigQueryIntegration:
                     FROM {project_id}.{database}.users
                     WHERE user_id = 42
                 """,
-                execution_database="test_db",  # Different database
+                default_namespace="test_db",  # Different database
                 use_physical_tables=use_physical_tables,
             )
 
@@ -685,8 +680,8 @@ class TestBigQueryIntegration:
             result_class=UserOrderSummary,
         )
         def query_decorator_pattern():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -700,7 +695,7 @@ class TestBigQueryIntegration:
                     GROUP BY u.user_id, u.name
                     ORDER BY u.user_id
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -730,8 +725,8 @@ class TestBigQueryIntegration:
 
         @sql_test()  # Empty decorator
         def query_testcase_pattern():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -745,7 +740,7 @@ class TestBigQueryIntegration:
                     GROUP BY u.user_id, u.name
                     ORDER BY u.user_id
                 """,
-                execution_database=database,
+                default_namespace=database,
                 mock_tables=[UsersMockTable(test_users), OrdersMockTable(test_orders)],
                 result_class=UserOrderSummary,
                 adapter_type="bigquery",
@@ -778,8 +773,8 @@ class TestBigQueryIntegration:
 
         @sql_test(mock_tables=[UsersMockTable(test_users), OrdersMockTable(test_orders)])
         def query_mixed_pattern():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -793,7 +788,7 @@ class TestBigQueryIntegration:
                     GROUP BY u.user_id, u.name
                     ORDER BY u.user_id
                 """,
-                execution_database=database,
+                default_namespace=database,
                 # We define result_class here instead of in decorator
                 result_class=UserOrderSummary,
                 adapter_type="bigquery",
@@ -807,6 +802,67 @@ class TestBigQueryIntegration:
         assert results[0].user_id == 1
         assert results[0].total_orders == 2
         assert results[0].total_amount == Decimal("250.00")
+
+    def test_unqualified_table_names_with_default_namespace(self, use_physical_tables):
+        """Test how default_namespace resolves unqualified table names to mock tables.
+
+        This test demonstrates the key role of default_namespace:
+        - Query uses unqualified table names: 'users' and 'orders'
+        - default_namespace='test-project.test_dataset' qualifies them to:
+          'test-project.test_dataset.users' and 'test-project.test_dataset.orders'
+        - These qualified names must match mock table get_qualified_name() values
+        """
+
+        test_users = [
+            User(1, "Alice", "alice@example.com", date(2023, 1, 1)),
+            User(2, "Bob", "bob@example.com", date(2023, 1, 2)),
+        ]
+
+        test_orders = [
+            Order(101, 1, Decimal("100.00"), date(2023, 2, 1)),
+            Order(102, 2, Decimal("150.00"), date(2023, 2, 2)),
+        ]
+
+        @sql_test(
+            adapter_type="bigquery",
+            mock_tables=[UsersMockTable(test_users), OrdersMockTable(test_orders)],
+            result_class=UserOrderSummary,
+        )
+        def query_unqualified_tables():
+            return TestCase(
+                # Note: SQL uses unqualified table names 'users' and 'orders'
+                query="""
+                    SELECT
+                        u.user_id,
+                        u.name,
+                        COUNT(o.order_id) as total_orders,
+                        SUM(o.amount) as total_amount
+                    FROM users u
+                    LEFT JOIN orders o ON u.user_id = o.user_id
+                    GROUP BY u.user_id, u.name
+                    ORDER BY u.user_id
+                """,
+                # default_namespace provides the namespace to qualify table names
+                # 'users' becomes 'test-project.test_dataset.users'
+                # 'orders' becomes 'test-project.test_dataset.orders'
+                default_namespace="test-project.test_dataset",
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_unqualified_tables()
+
+        # Assertions - verifies that unqualified 'users' and 'orders' tables
+        # were correctly resolved to 'test-project.test_dataset.users' and
+        # 'test-project.test_dataset.orders' and matched with mock tables
+        assert len(results) == 2
+        assert results[0].user_id == 1
+        assert results[0].name == "Alice"
+        assert results[0].total_orders == 1
+        assert results[0].total_amount == Decimal("100.00")
+        assert results[1].user_id == 2
+        assert results[1].name == "Bob"
+        assert results[1].total_orders == 1
+        assert results[1].total_amount == Decimal("150.00")
 
 
 @pytest.mark.integration
@@ -854,8 +910,8 @@ class TestBigQueryPerformance:
             result_class=LargeDatasetResult,
         )
         def query_large_dataset():
-            project_id = os.getenv("BIGQUERY_PROJECT_ID", "bigquery-public-data")
-            database = os.getenv("BIGQUERY_DATABASE", "analytics_db")
+            project_id = "test-project"
+            database = "test_dataset"
             return TestCase(
                 query=f"""
                     SELECT
@@ -868,7 +924,7 @@ class TestBigQueryPerformance:
                     INNER JOIN {project_id}.{database}.orders o ON u.user_id = o.user_id
                     WHERE u.is_premium = TRUE
                 """,
-                execution_database=database,
+                default_namespace=database,
                 use_physical_tables=use_physical_tables,
             )
 

--- a/tests/integration/test_complex_types_integration.py
+++ b/tests/integration/test_complex_types_integration.py
@@ -114,7 +114,7 @@ class TestComplexTypesIntegration(unittest.TestCase):
                     FROM complex_types
                     ORDER BY id
                 """,
-                execution_database=os.getenv("AWS_ATHENA_DATABASE", "test_db"),
+                default_namespace=os.getenv("AWS_ATHENA_DATABASE", "test_db"),
             )
 
         results = query_athena_complex_types()
@@ -198,7 +198,7 @@ class TestComplexTypesIntegration(unittest.TestCase):
                     FROM complex_types
                     ORDER BY id
                 """,
-                execution_database=os.getenv("GCP_PROJECT_ID", "test_project"),
+                default_namespace=os.getenv("GCP_PROJECT_ID", "test_project"),
             )
 
         results = query_bigquery_complex_types()
@@ -283,7 +283,7 @@ class TestComplexTypesIntegration(unittest.TestCase):
                     FROM complex_types
                     ORDER BY id
                 """,
-                execution_database="test_db",
+                default_namespace="test_db",
             )
 
         results = query_redshift_complex_types()
@@ -367,7 +367,7 @@ class TestComplexTypesIntegration(unittest.TestCase):
                     FROM complex_types
                     ORDER BY id
                 """,
-                execution_database=os.getenv("SNOWFLAKE_DATABASE", "test_db"),
+                default_namespace=os.getenv("SNOWFLAKE_DATABASE", "test_db"),
             )
 
         results = query_snowflake_complex_types()
@@ -449,7 +449,7 @@ class TestComplexTypesIntegration(unittest.TestCase):
                     FROM complex_types
                     ORDER BY id
                 """,
-                execution_database="memory",
+                default_namespace="memory",
             )
 
         results = query_trino_complex_types()

--- a/tests/integration/test_primitive_types_integration.py
+++ b/tests/integration/test_primitive_types_integration.py
@@ -300,7 +300,7 @@ class TestPrimitiveTypesIntegration:
                     FROM primitive_types
                     ORDER BY int_col DESC
                 """,
-                execution_database=self.database_name,
+                default_namespace=self.database_name,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -539,7 +539,7 @@ class TestPrimitiveTypesIntegration:
                     FROM all_optional_table
                     ORDER BY optional_int
                 """,
-                execution_database=self.database_name,
+                default_namespace=self.database_name,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -638,7 +638,7 @@ class TestSnowflakePrimitiveTypesIntegration:
                     FROM primitive_types
                     ORDER BY int_col DESC
                 """,
-                execution_database=self.database_name,
+                default_namespace=self.database_name,
                 use_physical_tables=use_physical_tables,
             )
 
@@ -735,7 +735,7 @@ class TestSnowflakePrimitiveTypesIntegration:
                     FROM all_optional_table
                     ORDER BY optional_int
                 """,
-                execution_database=self.database_name,
+                default_namespace=self.database_name,
                 use_physical_tables=use_physical_tables,
             )
 

--- a/tests/integration/test_snowflake_integration.py
+++ b/tests/integration/test_snowflake_integration.py
@@ -1,6 +1,5 @@
 """Integration tests for Snowflake adapter with pytest configuration."""
 
-import os
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -79,9 +78,7 @@ class CustomersMockTable(BaseMockTable):
     """Mock table for customers data."""
 
     def get_database_name(self) -> str:
-        database = os.getenv("SNOWFLAKE_DATABASE", "TEST_DB")
-        schema = os.getenv("SNOWFLAKE_SCHEMA", "SQLTESTING")
-        return f"{database}.{schema}"
+        return "test_db.public"
 
     def get_table_name(self) -> str:
         return "customers"
@@ -91,9 +88,7 @@ class OrdersMockTable(BaseMockTable):
     """Mock table for orders data."""
 
     def get_database_name(self) -> str:
-        database = os.getenv("SNOWFLAKE_DATABASE", "TEST_DB")
-        schema = os.getenv("SNOWFLAKE_SCHEMA", "SQLTESTING")
-        return f"{database}.{schema}"
+        return "test_db.public"
 
     def get_table_name(self) -> str:
         return "orders"
@@ -103,9 +98,7 @@ class ProductsMockTable(BaseMockTable):
     """Mock table for products data."""
 
     def get_database_name(self) -> str:
-        database = os.getenv("SNOWFLAKE_DATABASE", "TEST_DB")
-        schema = os.getenv("SNOWFLAKE_SCHEMA", "SQLTESTING")
-        return f"{database}.{schema}"
+        return "test_db.public"
 
     def get_table_name(self) -> str:
         return "products"
@@ -193,7 +186,7 @@ class TestSnowflakeIntegration:
                         CAST(0.00 AS DECIMAL(10,2)) as total_amount
                     FROM customers WHERE customer_id = 1
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -229,7 +222,7 @@ class TestSnowflakeIntegration:
                     GROUP BY c.customer_id, c.name
                     ORDER BY total_spent DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -260,7 +253,7 @@ class TestSnowflakeIntegration:
                     WHERE signup_date >= DATE '2023-02-01'
                     ORDER BY signup_date DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -290,7 +283,7 @@ class TestSnowflakeIntegration:
                     WHERE DATE(order_date) >= DATE '2023-04-01'
                     AND status IN ('completed', 'pending')
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -336,7 +329,7 @@ class TestSnowflakeIntegration:
                     WHERE lifetime_value IS NOT NULL OR customer_id = 2
                     ORDER BY customer_id
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -367,7 +360,7 @@ class TestSnowflakeIntegration:
                     WHERE LENGTH(name) > 8
                     ORDER BY name
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -397,7 +390,7 @@ class TestSnowflakeIntegration:
                     HAVING COUNT(*) >= 1
                     ORDER BY avg_price DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -429,7 +422,7 @@ class TestSnowflakeIntegration:
                     AND lifetime_value > CAST(1000.00 AS DECIMAL(10,2))
                     ORDER BY lifetime_value DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -474,7 +467,7 @@ class TestSnowflakeIntegration:
                     WHERE total_spent > CAST(0.00 AS DECIMAL(10,2))
                     ORDER BY total_spent DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -511,7 +504,7 @@ class TestSnowflakeIntegration:
                         END
                     ORDER BY avg_price DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -551,7 +544,7 @@ class TestSnowflakeIntegration:
                     )
                     ORDER BY c.customer_id
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -581,7 +574,7 @@ class TestSnowflakeIntegration:
                     WHERE EXTRACT(YEAR FROM order_date) = 2023
                     AND EXTRACT(MONTH FROM order_date) >= 3
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -610,7 +603,7 @@ class TestSnowflakeIntegration:
                     WHERE price BETWEEN CAST(100.00 AS DECIMAL(10,2))
                                    AND CAST(1000.00 AS DECIMAL(10,2))
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -643,7 +636,7 @@ class TestSnowflakeIntegration:
                     FROM premium_customers
                     ORDER BY lifetime_value DESC
                 """,
-                execution_database="TEST_DB.SQLTESTING",
+                default_namespace="test_db.public",
                 use_physical_tables=use_physical_tables,
             )
 
@@ -652,3 +645,129 @@ class TestSnowflakeIntegration:
         assert len(results) >= 1
         assert all(hasattr(result, "customer_id") for result in results)
         assert results[0].customer_id == 3  # Carol Davis has highest lifetime_value
+
+    def test_unqualified_table_names_with_default_namespace(self, use_physical_tables):
+        """Test how default_namespace resolves unqualified table names to mock tables.
+
+        This test demonstrates the key role of default_namespace for Snowflake:
+        - Query uses unqualified table names: 'customers' and 'orders'
+        - default_namespace='test_db.public' qualifies them to:
+          'test_db.public.customers' and 'test_db.public.orders'
+        - These qualified names must match mock table get_qualified_name() values
+        """
+
+        test_customers = [
+            Customer(1, "Alice", "alice@example.com", date(2023, 1, 1), True, Decimal("1000.00")),
+            Customer(2, "Bob", "bob@example.com", date(2023, 1, 2), False, Decimal("500.00")),
+        ]
+
+        test_orders = [
+            Order(101, 1, datetime(2023, 2, 1, 10, 0, 0), Decimal("200.00"), "completed"),
+            Order(102, 2, datetime(2023, 2, 2, 11, 0, 0), Decimal("150.00"), "completed"),
+        ]
+
+        @sql_test(
+            adapter_type="snowflake",
+            mock_tables=[CustomersMockTable(test_customers), OrdersMockTable(test_orders)],
+            result_class=OrderSummaryResult,
+        )
+        def query_unqualified_tables():
+            return TestCase(
+                # Note: SQL uses unqualified table names 'customers' and 'orders'
+                query="""
+                    SELECT
+                        c.customer_id,
+                        c.name as customer_name,
+                        COUNT(o.order_id) as order_count,
+                        COALESCE(SUM(o.amount), CAST(0.00 AS DECIMAL(10,2))) as total_spent,
+                        COALESCE(AVG(o.amount), CAST(0.00 AS DECIMAL(10,2))) as avg_order_value
+                    FROM customers c
+                    LEFT JOIN orders o ON c.customer_id = o.customer_id
+                    WHERE o.status = 'completed'
+                    GROUP BY c.customer_id, c.name
+                    ORDER BY c.customer_id
+                """,
+                # default_namespace provides the namespace to qualify table names
+                # 'customers' becomes 'test_db.public.customers'
+                # 'orders' becomes 'test_db.public.orders'
+                default_namespace="test_db.public",
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_unqualified_tables()
+
+        # Assertions - verifies that unqualified 'customers' and 'orders' tables
+        # were correctly resolved to 'test_db.public.customers' and 'test_db.public.orders'
+        # and matched with mock tables
+        assert len(results) == 2
+        assert results[0].customer_id == 1
+        assert results[0].customer_name == "Alice"
+        assert results[0].order_count == 1
+        assert results[0].total_spent == Decimal("200.00")
+        assert results[1].customer_id == 2
+        assert results[1].customer_name == "Bob"
+        assert results[1].order_count == 1
+        assert results[1].total_spent == Decimal("150.00")
+
+    def test_case_insensitive_table_matching(self, use_physical_tables):
+        """Test case-insensitive table name matching (now generic for all SQL databases).
+
+        This test verifies that case-insensitive matching works correctly:
+        - Mock tables use lowercase database context: 'test_db.public'
+        - SQL query uses mixed case table names: 'CUSTOMERS', 'orders'
+        - execution_database uses lowercase: 'test_db.public'
+        - Framework should match these case-insensitively (generic SQL behavior)
+        """
+
+        test_customers = [
+            Customer(1, "Alice", "alice@example.com", date(2023, 1, 1), True, Decimal("1000.00")),
+            Customer(2, "Bob", "bob@example.com", date(2023, 1, 2), False, Decimal("500.00")),
+        ]
+
+        test_orders = [
+            Order(101, 1, datetime(2023, 2, 1, 10, 0, 0), Decimal("200.00"), "completed"),
+            Order(102, 2, datetime(2023, 2, 2, 11, 0, 0), Decimal("150.00"), "completed"),
+        ]
+
+        @sql_test(
+            adapter_type="snowflake",
+            mock_tables=[CustomersMockTable(test_customers), OrdersMockTable(test_orders)],
+            result_class=OrderSummaryResult,
+        )
+        def query_mixed_case_tables():
+            return TestCase(
+                # Note: SQL uses mixed case table names to test case-insensitive matching
+                # 'CUSTOMERS' (uppercase) should match mock table 'test_db.public.customers'
+                # 'orders' (lowercase) should match mock table 'test_db.public.orders'
+                query="""
+                    SELECT
+                        c.customer_id,
+                        c.name as customer_name,
+                        COUNT(o.order_id) as order_count,
+                        COALESCE(SUM(o.amount), CAST(0.00 AS DECIMAL(10,2))) as total_spent,
+                        COALESCE(AVG(o.amount), CAST(0.00 AS DECIMAL(10,2))) as avg_order_value
+                    FROM CUSTOMERS c
+                    LEFT JOIN orders o ON c.customer_id = o.customer_id
+                    WHERE o.status = 'completed'
+                    GROUP BY c.customer_id, c.name
+                    ORDER BY c.customer_id
+                """,
+                # execution_database uses lowercase - should work with mixed case table names
+                default_namespace="test_db.public",
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_mixed_case_tables()
+
+        # Assertions - verifies that mixed case table names 'CUSTOMERS' and 'orders'
+        # were correctly matched with lowercase mock tables 'test_db.public.customers'
+        # and 'test_db.public.orders' using case-insensitive matching
+        assert len(results) == 2
+        assert results[0].customer_id == 1
+        assert results[0].customer_name == "Alice"
+        assert results[0].order_count == 1
+        assert results[0].total_spent == Decimal("200.00")
+        assert results[1].customer_id == 2
+        assert results[1].customer_name == "Bob"
+        assert results[1].order_count == 1
+        assert results[1].total_spent == Decimal("150.00")

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -142,7 +142,7 @@ class TestAthenaIntegration(unittest.TestCase):
             def test_athena_query():
                 return TestCase(
                     query="SELECT id, name FROM users WHERE id = 1",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test

--- a/tests/test_athena_physical_tables.py
+++ b/tests/test_athena_physical_tables.py
@@ -130,7 +130,7 @@ class TestAthenaPhysicalTables(unittest.TestCase):
                 return TestCase(
                     query="SELECT id, name, price, category FROM products"
                     + " WHERE category = 'Electronics'",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test
@@ -203,7 +203,7 @@ class TestAthenaPhysicalTables(unittest.TestCase):
                 use_physical_tables=True,  # Force physical tables
             )
             def test_athena_large_query():
-                return TestCase(query=large_query, execution_database="test_db")
+                return TestCase(query=large_query, default_namespace="test_db")
 
             # Execute the test with physical tables
             results = test_athena_large_query()

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -137,7 +137,7 @@ class TestBigQueryIntegration(unittest.TestCase):
             def test_bigquery_query():
                 return TestCase(
                     query="SELECT id, name FROM users WHERE id = 1",
-                    execution_database="test_dataset",
+                    default_namespace="test_dataset",
                 )
 
             # Execute the test

--- a/tests/test_bigquery_physical_tables.py
+++ b/tests/test_bigquery_physical_tables.py
@@ -116,7 +116,7 @@ class TestBigQueryPhysicalTables(unittest.TestCase):
                 return TestCase(
                     query="SELECT id, name, price, category FROM products"
                     + " WHERE category = 'Electronics'",
-                    execution_database="test_dataset",
+                    default_namespace="test_dataset",
                 )
 
             # Execute the test
@@ -180,7 +180,7 @@ class TestBigQueryPhysicalTables(unittest.TestCase):
                 use_physical_tables=True,
             )
             def test_bigquery_large_query():
-                return TestCase(query=large_query, execution_database="test_dataset")
+                return TestCase(query=large_query, default_namespace="test_dataset")
 
             # Execute the test
             results = test_bigquery_large_query()

--- a/tests/test_core_extra.py
+++ b/tests/test_core_extra.py
@@ -52,10 +52,10 @@ class TestSQLTestCaseExtra(unittest.TestCase):
         self.assertFalse(SQLTestCase.__test__)
 
         # Test basic instantiation
-        test_case = SQLTestCase(query="SELECT * FROM test", execution_database="test_db")
+        test_case = SQLTestCase(query="SELECT * FROM test", default_namespace="test_db")
 
         self.assertEqual(test_case.query, "SELECT * FROM test")
-        self.assertEqual(test_case.execution_database, "test_db")
+        self.assertEqual(test_case.default_namespace, "test_db")
         self.assertIsNone(test_case.mock_tables)
         self.assertIsNone(test_case.result_class)
         self.assertFalse(test_case.use_physical_tables)
@@ -81,7 +81,7 @@ class TestSQLTestFrameworkExtra(unittest.TestCase):
         """Test error when mock_tables is None."""
         test_case = SQLTestCase(
             query="SELECT * FROM test",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=None,  # This should cause an error
             result_class=dict,
         )
@@ -97,7 +97,7 @@ class TestSQLTestFrameworkExtra(unittest.TestCase):
 
         test_case = SQLTestCase(
             query="SELECT * FROM test",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[mock_table],
             result_class=None,  # This should cause an error
         )
@@ -119,7 +119,7 @@ class TestSQLTestFrameworkExtra(unittest.TestCase):
 
         test_case = SQLTestCase(
             query="INVALID SQL",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[mock_table],
             result_class=dict,
         )
@@ -136,7 +136,7 @@ class TestSQLTestFrameworkExtra(unittest.TestCase):
 
         test_case = SQLTestCase(
             query="SELECT * FROM test",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[mock_table],
             result_class=None,  # This will cause an error
         )
@@ -196,7 +196,7 @@ class TestSQLTestFrameworkCTEHandling(unittest.TestCase):
 
             test_case = SQLTestCase(
                 query="WITH existing AS (SELECT 1) SELECT * FROM test",
-                execution_database="test_db",
+                default_namespace="test_db",
                 mock_tables=[mock_table],
                 result_class=dict,
             )

--- a/tests/test_core_framework.py
+++ b/tests/test_core_framework.py
@@ -513,7 +513,7 @@ class TestSQLTestFramework(unittest.TestCase):
         """Test run_test raises error when mock_tables is None."""
         test_case = SQLTestCase(
             query="SELECT * FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=None,
             result_class=SampleResult,
         )
@@ -527,7 +527,7 @@ class TestSQLTestFramework(unittest.TestCase):
         """Test run_test raises error when result_class is None."""
         test_case = SQLTestCase(
             query="SELECT * FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[SampleUserMockTable(self.test_users)],
             result_class=None,
         )
@@ -550,7 +550,7 @@ class TestSQLTestFramework(unittest.TestCase):
 
             test_case = SQLTestCase(
                 query="SELECT * FROM users WHERE name = 'very long name that exceeds limit'",
-                execution_database="test_db",
+                default_namespace="test_db",
                 mock_tables=[SampleUserMockTable(self.test_users)],
                 result_class=SampleResult,
             )
@@ -564,7 +564,7 @@ class TestSQLTestFramework(unittest.TestCase):
         """Test that temp tables are cleaned up even when exceptions occur."""
         test_case = SQLTestCase(
             query="SELECT * FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[SampleUserMockTable(self.test_users)],
             result_class=SampleResult,
             use_physical_tables=True,
@@ -585,7 +585,7 @@ class TestSQLTestFramework(unittest.TestCase):
         """Test successful test run with CTE mode."""
         test_case = SQLTestCase(
             query="SELECT id, name FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[SampleUserMockTable(self.test_users)],
             result_class=SampleUser,
             use_physical_tables=False,
@@ -632,7 +632,7 @@ class TestSQLTestFramework(unittest.TestCase):
         """Test successful test run with physical tables mode."""
         test_case = SQLTestCase(
             query="SELECT id, name FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[SampleUserMockTable(self.test_users)],
             result_class=SampleUser,
             use_physical_tables=True,
@@ -677,11 +677,11 @@ class TestSQLTestCaseClass(unittest.TestCase):
         """Test SQLTestCase can be created with required fields."""
         test_case = SQLTestCase(
             query="SELECT * FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
         )
 
         assert test_case.query == "SELECT * FROM users"
-        assert test_case.execution_database == "test_db"
+        assert test_case.default_namespace == "test_db"
         assert test_case.mock_tables is None
         assert test_case.result_class is None
         assert test_case.use_physical_tables is False
@@ -694,7 +694,7 @@ class TestSQLTestCaseClass(unittest.TestCase):
 
         test_case = SQLTestCase(
             query="SELECT * FROM users",
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[mock_table],
             result_class=SampleUser,
             use_physical_tables=True,
@@ -703,7 +703,7 @@ class TestSQLTestCaseClass(unittest.TestCase):
         )
 
         assert test_case.query == "SELECT * FROM users"
-        assert test_case.execution_database == "test_db"
+        assert test_case.default_namespace == "test_db"
         assert test_case.mock_tables == [mock_table]
         assert test_case.result_class == SampleUser
         assert test_case.use_physical_tables is True

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -23,9 +23,9 @@ class TestPublicAPIImports(unittest.TestCase):
         # Should be an alias for SQLTestCase
         assert TestCase is not None
         # Test that it can be instantiated
-        test_case = TestCase(query="SELECT 1", execution_database="test_db")
+        test_case = TestCase(query="SELECT 1", default_namespace="test_db")
         assert test_case.query == "SELECT 1"
-        assert test_case.execution_database == "test_db"
+        assert test_case.default_namespace == "test_db"
 
     def test_import_mock_table_base(self):
         """Test that BaseMockTable can be imported."""
@@ -81,7 +81,7 @@ class TestPublicAPIImports(unittest.TestCase):
         # Test that decorator can be applied
         @sql_test
         def test_function():
-            return TestCase(query="SELECT 1 as test_col", execution_database="test_db")
+            return TestCase(query="SELECT 1 as test_col", default_namespace="test_db")
 
         # Should not raise an error and should be callable
         assert callable(test_function)
@@ -97,8 +97,8 @@ class TestPublicAPIImports(unittest.TestCase):
         assert TestCase is SQLTestCase
 
         # Should have same functionality
-        test_case1 = TestCase(query="SELECT 1", execution_database="db1")
-        test_case2 = SQLTestCase(query="SELECT 1", execution_database="db1")
+        test_case1 = TestCase(query="SELECT 1", default_namespace="db1")
+        test_case2 = SQLTestCase(query="SELECT 1", default_namespace="db1")
 
         assert type(test_case1) is type(test_case2)
         assert test_case1.query == test_case2.query
@@ -220,10 +220,10 @@ class TestBackwardCompatibility(unittest.TestCase):
         from sql_testing_library import BaseMockTable, TestCase
 
         # TestCase should be usable for creating test cases
-        test_case = TestCase(query="SELECT 1 as id, 'test' as name", execution_database="test_db")
+        test_case = TestCase(query="SELECT 1 as id, 'test' as name", default_namespace="test_db")
 
         assert test_case.query is not None
-        assert test_case.execution_database == "test_db"
+        assert test_case.default_namespace == "test_db"
 
         # BaseMockTable should be an abstract base that can be subclassed
         class TestMockTable(BaseMockTable):
@@ -245,14 +245,14 @@ class TestBackwardCompatibility(unittest.TestCase):
         # Basic usage without arguments
         @sql_test
         def test_basic():
-            return TestCase(query="SELECT 1", execution_database="db")
+            return TestCase(query="SELECT 1", default_namespace="db")
 
         assert callable(test_basic)
 
         # Usage with adapter type (just test that decorator accepts the parameter)
         @sql_test(adapter_type="bigquery")
         def test_with_adapter():
-            return TestCase(query="SELECT 1", execution_database="db")
+            return TestCase(query="SELECT 1", default_namespace="db")
 
         assert callable(test_with_adapter)
 

--- a/tests/test_pydantic_core_functionality.py
+++ b/tests/test_pydantic_core_functionality.py
@@ -218,7 +218,7 @@ class TestPydanticCoreFramework(unittest.TestCase):
                     GROUP BY p.id, p.name, p.category
                     ORDER BY total_revenue DESC
                 """,
-                execution_database="test_project",
+                default_namespace="test_project",
             )
 
         # Mock the adapter to avoid actual database connection

--- a/tests/test_pydantic_models_integration.py
+++ b/tests/test_pydantic_models_integration.py
@@ -213,7 +213,7 @@ class TestPydanticModelsIntegration(unittest.TestCase):
                              u.department_id
                     ORDER BY total_spent DESC
                 """,
-                execution_database=os.getenv("GCP_PROJECT_ID", "test_project"),
+                default_namespace=os.getenv("GCP_PROJECT_ID", "test_project"),
             )
 
         results = query_user_order_summary()
@@ -279,7 +279,7 @@ class TestPydanticModelsIntegration(unittest.TestCase):
                              u.department_id
                     ORDER BY total_spent DESC
                 """,
-                execution_database=os.getenv("AWS_ATHENA_DATABASE", "test_db"),
+                default_namespace=os.getenv("AWS_ATHENA_DATABASE", "test_db"),
             )
 
         results = query_user_order_summary()
@@ -325,7 +325,7 @@ class TestPydanticModelsIntegration(unittest.TestCase):
                              u.department_id
                     ORDER BY total_spent DESC
                 """,
-                execution_database="test_db",
+                default_namespace="test_db",
             )
 
         results = query_user_order_summary()
@@ -372,7 +372,7 @@ class TestPydanticModelsIntegration(unittest.TestCase):
                              u.department_id
                     ORDER BY total_spent DESC
                 """,
-                execution_database="memory",
+                default_namespace="memory",
             )
 
         results = query_user_order_summary()
@@ -412,7 +412,7 @@ class TestPydanticModelsIntegration(unittest.TestCase):
                              u.department_id
                     ORDER BY total_spent DESC
                 """,
-                execution_database=os.getenv("SNOWFLAKE_DATABASE", "test_db"),
+                default_namespace=os.getenv("SNOWFLAKE_DATABASE", "test_db"),
             )
 
         results = query_user_order_summary()

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -464,7 +464,7 @@ class TestSQLTestDecoratorFunction(unittest.TestCase):
 
         @sql_test()
         def test_function():
-            return SQLTestCase(query="SELECT 1 as result", execution_database="test")
+            return SQLTestCase(query="SELECT 1 as result", default_namespace="test")
 
         # Check that function is marked as decorated
         self.assertTrue(hasattr(test_function, "_sql_test_decorated"))
@@ -485,7 +485,7 @@ class TestSQLTestDecoratorFunction(unittest.TestCase):
 
         @sql_test(mock_tables=[mock_table], use_physical_tables=True, adapter_type="bigquery")
         def test_function():
-            return SQLTestCase(query="SELECT * FROM test_table", execution_database="test")
+            return SQLTestCase(query="SELECT * FROM test_table", default_namespace="test")
 
         # Check that function is marked as decorated
         self.assertTrue(hasattr(test_function, "_sql_test_decorated"))
@@ -494,7 +494,7 @@ class TestSQLTestDecoratorFunction(unittest.TestCase):
         """Test that multiple sql_test decorators raise an error."""
 
         def test_function():
-            return SQLTestCase(query="SELECT 1", execution_database="test")
+            return SQLTestCase(query="SELECT 1", default_namespace="test")
 
         # Apply first decorator
         decorated_once = sql_test()(test_function)
@@ -542,7 +542,7 @@ class TestSQLTestDecoratorFunction(unittest.TestCase):
             # Return SQLTestCase with different values
             return SQLTestCase(
                 query="SELECT 1",
-                execution_database="test",
+                default_namespace="test",
                 mock_tables=[mock_table1],
                 use_physical_tables=False,
                 adapter_type="bigquery",

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -142,7 +142,7 @@ class TestRedshiftIntegration(unittest.TestCase):
             def test_redshift_query():
                 return TestCase(
                     query="SELECT id, name FROM users WHERE id = 1",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test

--- a/tests/test_redshift_physical_tables.py
+++ b/tests/test_redshift_physical_tables.py
@@ -114,7 +114,7 @@ class TestRedshiftPhysicalTables(unittest.TestCase):
                 return TestCase(
                     query="SELECT id, name, price, category FROM products"
                     + " WHERE category = 'Electronics'",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test
@@ -196,7 +196,7 @@ class TestRedshiftPhysicalTables(unittest.TestCase):
                 use_physical_tables=True,  # Force physical tables
             )
             def test_redshift_large_query():
-                return TestCase(query=large_query, execution_database="test_db")
+                return TestCase(query=large_query, default_namespace="test_db")
 
             # Execute the test with physical tables
             results = test_redshift_large_query()

--- a/tests/test_snowflake_physical_tables.py
+++ b/tests/test_snowflake_physical_tables.py
@@ -124,7 +124,7 @@ class TestSnowflakePhysicalTables(unittest.TestCase):
         # Create a test case
         test_case = SQLTestCase(
             query=sql,
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[PersonMockTable(person_dicts)],
             use_physical_tables=True,
         )
@@ -134,7 +134,7 @@ class TestSnowflakePhysicalTables(unittest.TestCase):
             # Manually replicate the needed operations without calling run directly
             referenced_tables = tester._parse_sql_tables(test_case.query)
             resolved_tables = tester._resolve_table_names(
-                referenced_tables, test_case.execution_database
+                referenced_tables, test_case.default_namespace
             )
             table_mapping = tester._create_table_mapping(resolved_tables, test_case.mock_tables)
             final_query = tester._execute_with_physical_tables(
@@ -268,7 +268,7 @@ class TestSnowflakePhysicalTables(unittest.TestCase):
         # Create a test case
         test_case = SQLTestCase(
             query=sql,
-            execution_database="test_db",
+            default_namespace="test_db",
             mock_tables=[
                 PersonMockTable(person_dicts),
                 DepartmentMockTable(dept_dicts),
@@ -280,7 +280,7 @@ class TestSnowflakePhysicalTables(unittest.TestCase):
         # Manually replicate the needed operations without calling run directly
         referenced_tables = tester._parse_sql_tables(test_case.query)
         resolved_tables = tester._resolve_table_names(
-            referenced_tables, test_case.execution_database
+            referenced_tables, test_case.default_namespace
         )
         table_mapping = tester._create_table_mapping(resolved_tables, test_case.mock_tables)
         final_query = tester._execute_with_physical_tables(

--- a/tests/test_trino.py
+++ b/tests/test_trino.py
@@ -147,7 +147,7 @@ class TestTrinoIntegration(unittest.TestCase):
             def test_trino_query():
                 return TestCase(
                     query="SELECT id, name FROM users WHERE id = 1",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test

--- a/tests/test_trino_physical_tables.py
+++ b/tests/test_trino_physical_tables.py
@@ -119,7 +119,7 @@ class TestTrinoPhysicalTables(unittest.TestCase):
                 return TestCase(
                     query="SELECT id, name, price, category FROM products"
                     + " WHERE category = 'Electronics'",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test
@@ -202,7 +202,7 @@ class TestTrinoPhysicalTables(unittest.TestCase):
             def test_trino_empty_table():
                 return TestCase(
                     query="SELECT id, name, price, category FROM products LIMIT 0",
-                    execution_database="test_db",
+                    default_namespace="test_db",
                 )
 
             # Execute the test - this primarily verifies that the empty table can be
@@ -245,7 +245,7 @@ class TestTrinoPhysicalTables(unittest.TestCase):
                 use_physical_tables=True,  # Force physical tables
             )
             def test_trino_large_query():
-                return TestCase(query=large_query, execution_database="test_db")
+                return TestCase(query=large_query, default_namespace="test_db")
 
             # Execute the test with physical tables
             results = test_trino_large_query()


### PR DESCRIPTION
BREAKING CHANGE: SQLTestCase parameter execution_database renamed to default_namespace for clarity

  - feat: add default_namespace parameter to SQLTestCase with backward compatibility
  - feat: implement generic case-insensitive table name matching for all SQL databases
  - refactor: remove os.getenv() dependencies from integration tests
  - refactor: standardize database contexts across all adapters (BigQuery: test-project.test_dataset, Athena/Redshift: test_db, Snowflake: test_db.public, Trino: memory.default)
  - test: add unqualified table name resolution tests for all adapters
  - test: add case-insensitive table matching tests
  - fix: add missing avg_order_value field in Trino integration test
  - fix: correct result class in Redshift test (CustomerOrderSummaryResult -> OrderSummaryResult)
  - docs: update README.md with database context understanding section
  - docs: document default_namespace parameter and migration guidance

  The execution_database parameter is deprecated with warnings but remains functional.
  The new default_namespace parameter better reflects its purpose as a namespace
  prefix for qualifying unqualified table names in SQL queries.


fixes #14 