### PR TITLE
docs: Add GitHub Pages documentation and update existing docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,15 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Jekyll documentation build output
+docs/_site/
+docs/.sass-cache/
+docs/.jekyll-cache/
+docs/.jekyll-metadata
+docs/vendor/
+docs/.bundle/
+docs/Gemfile.lock
+
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -180,3 +189,5 @@ pytest.ini
 
 # Local development markers
 .sql_testing_root
+.jekyll-cache
+_site/

--- a/README.md
+++ b/README.md
@@ -512,6 +512,12 @@ def test_pattern_3():
 # Run all tests
 pytest test_users.py
 
+# Run only SQL tests (using the sql_test marker)
+pytest -m sql_test
+
+# Exclude SQL tests
+pytest -m "not sql_test"
+
 # Run a specific test
 pytest test_users.py::test_user_query
 
@@ -655,7 +661,14 @@ The library supports flexible ways to configure your tests:
 
 ### Using Different Database Adapters in Tests
 
-You can specify which database adapter to use for individual tests:
+The adapter specified in `[sql_testing]` section acts as the default adapter for all tests. When you don't specify an `adapter_type` in your test, it uses this default.
+
+```ini
+[sql_testing]
+adapter = snowflake  # This becomes the default for all tests
+```
+
+You can override the default adapter for individual tests:
 
 ```python
 # Use BigQuery adapter for this test
@@ -721,11 +734,16 @@ def test_snowflake_query():
 
 The adapter_type parameter will use the configuration from the corresponding section in pytest.ini, such as `[sql_testing.bigquery]`, `[sql_testing.athena]`, `[sql_testing.redshift]`, `[sql_testing.trino]`, or `[sql_testing.snowflake]`.
 
+**Default Adapter Behavior:**
+- If `adapter_type` is not specified in the test, the library uses the adapter from `[sql_testing]` section's `adapter` setting
+- If no adapter is specified in the `[sql_testing]` section, it defaults to "bigquery"
+- Each adapter reads its configuration from `[sql_testing.<adapter_name>]` section
+
 ### Adapter-Specific Features
 
 #### BigQuery Adapter
 - Supports Google Cloud BigQuery service
-- Uses STRUCT and UNNEST for efficient CTE creation
+- Uses UNION ALL pattern for CTE creation with complex data types
 - Handles authentication via service account or application default credentials
 
 #### Athena Adapter

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,25 @@
+# Jekyll build output
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+# Bundle directory
+vendor/
+.bundle/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Ruby version management
+.ruby-version
+.ruby-gemset
+
+# Bundler
+Gemfile.lock

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,28 @@
+source "https://rubygems.org"
+
+# GitHub Pages gem - includes Jekyll and all necessary dependencies
+gem "github-pages", group: :jekyll_plugins
+
+# Additional plugins
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-seo-tag"
+  gem "jekyll-sitemap"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+# Theme
+gem "just-the-docs"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,80 @@
+# SQL Testing Library Documentation
+
+This directory contains the documentation for the SQL Testing Library, built with Jekyll and hosted on GitHub Pages.
+
+## Documentation Structure
+
+```
+docs/
+├── _config.yml          # Jekyll configuration
+├── index.md            # Homepage
+├── getting-started.md  # Installation and quick start guide
+├── adapters.md         # Database adapter documentation
+├── api-reference.md    # Complete API reference
+├── examples.md         # Code examples and patterns
+├── troubleshooting.md  # Common issues and solutions
+├── migration.md        # Version migration guide
+└── assets/
+    └── css/
+        └── custom.css  # Custom styling
+```
+
+## Viewing Documentation
+
+### Online
+Visit: https://gurmeetsaran.github.io/sqltesting/
+
+### Locally
+
+#### Option 1: Using Docker (recommended - no Ruby required)
+```bash
+# Navigate to docs directory
+cd docs
+
+# Run Jekyll in Docker (works on ARM64/M1 Macs)
+docker run --rm -v "$PWD":/site -p 4000:4000 bretfisher/jekyll-serve
+
+# View at http://localhost:4000/sqltesting/
+
+# Note: Initial run will take a few minutes to install dependencies
+# Subsequent runs will be much faster
+```
+
+#### Option 2: Using Ruby (if you have Ruby 2.7+ installed)
+```bash
+# Navigate to docs directory
+cd docs
+
+# Install bundler compatible with your Ruby version
+gem install bundler -v 2.4.22
+
+# Install dependencies
+bundle install
+
+# Serve locally
+bundle exec jekyll serve
+
+# View at http://localhost:4000/sqltesting/
+```
+
+#### Option 3: Just push to GitHub (easiest)
+The easiest way is to push your changes and let GitHub Pages build it automatically. No local setup required!
+
+## Contributing to Documentation
+
+1. Edit the markdown files in this directory
+2. Follow the existing structure and formatting
+3. Test locally before submitting PR
+4. Keep examples practical and tested
+
+## Documentation Guidelines
+
+- Use clear, concise language
+- Include code examples for all features
+- Keep navigation structure flat and simple
+- Test all code examples
+- Update when adding new features
+
+## Jekyll Theme
+
+Using [Just the Docs](https://github.com/pmarsceill/just-the-docs) theme for clean, searchable documentation.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,175 @@
+# Site settings
+title: SQL Testing Library
+description: A Python library for testing SQL queries with mock data injection across multiple database platforms
+url: "https://gurmeetsaran.github.io"
+baseurl: "/sqltesting"
+
+# Repository
+repository: gurmeetsaran/sqltesting
+github_username: gurmeetsaran
+
+# Theme settings
+remote_theme: just-the-docs/just-the-docs
+# For local development, use:
+# theme: just-the-docs
+
+# Enable or disable the site search
+search_enabled: true
+search:
+  # Split pages into sections that can be searched individually
+  heading_level: 2
+  # Maximum amount of previews per search result
+  previews: 3
+  # Maximum amount of words to display before a matched word in the preview
+  preview_words_before: 5
+  # Maximum amount of words to display after a matched word in the preview
+  preview_words_after: 10
+  # Set the search token separator
+  tokenizer_separator: /[\s\-/]+/
+  # Display the relative url in search results
+  rel_url: true
+  # Enable or disable the search button that appears in the bottom right corner of every page
+  button: false
+
+# Aux links for the navigation
+aux_links:
+  "SQL Testing Library on GitHub":
+    - "//github.com/gurmeetsaran/sqltesting"
+  "View on PyPI":
+    - "//pypi.org/project/sql-testing-library/"
+
+# Makes Aux links open in a new tab
+aux_links_new_tab: true
+
+# Footer content
+footer_content: "Copyright &copy; 2024 SQL Testing Library Contributors. Distributed under the <a href=\"https://github.com/gurmeetsaran/sqltesting/blob/master/LICENSE\">MIT license.</a>"
+
+# Footer last edited timestamp
+last_edit_timestamp: true
+last_edit_time_format: "%b %e %Y at %I:%M %p"
+
+# Footer "Edit this page on GitHub" link
+gh_edit_link: true
+gh_edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/gurmeetsaran/sqltesting"
+gh_edit_branch: "master"
+gh_edit_source: docs
+gh_edit_view_mode: "tree"
+
+# Color scheme supports "light" (default) and "dark"
+color_scheme: light
+
+# Custom CSS
+custom_css: assets/css/custom.css
+
+# Google Analytics (if you have it)
+# ga_tracking: G-XXXXXXXXXX
+
+# Plugins
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Markdown settings
+markdown: kramdown
+kramdown:
+  syntax_highlighter_opts:
+    block:
+      line_numbers: false
+
+# Collections for different doc types
+collections:
+  tutorials:
+    permalink: "/:collection/:path/"
+    output: true
+
+just_the_docs:
+  collections:
+    tutorials:
+      name: Tutorials
+      nav_exclude: false
+      search_exclude: false
+
+# Exclude from Jekyll build
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/
+  - README.md
+  - CONTRIBUTING.md
+  - CODE_OF_CONDUCT.md
+  - LICENSE
+  - "*.py"
+  - "*.pyc"
+  - __pycache__/
+  - .pytest_cache/
+  - .mypy_cache/
+  - .ruff_cache/
+  - poetry.lock
+  - pyproject.toml
+  - pytest.ini
+  - mypy.ini
+  - .github/
+  - scripts/
+  - tests/
+  - src/
+  - htmlcov/
+  - coverage.xml
+  - .coverage
+
+# Include specific files
+include:
+  - _pages
+
+# Navigation structure
+nav_enabled: true
+nav_sort: case_insensitive
+
+# External navigation links
+nav_external_links:
+  - title: SQL Testing Library on GitHub
+    url: https://github.com/gurmeetsaran/sqltesting
+    hide_icon: false
+  - title: Report an Issue
+    url: https://github.com/gurmeetsaran/sqltesting/issues
+    hide_icon: false
+
+# Back to top link
+back_to_top: true
+back_to_top_text: "Back to top"
+
+# Code copy button
+enable_copy_code_button: true
+
+# Heading anchor links
+heading_anchors: true
+
+# Definition list support
+definition_list:
+  enable: true
+
+# Callout support
+callouts_level: quiet
+callouts:
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple
+  warning:
+    title: Warning
+    color: red
+
+# Mermaid diagram support
+mermaid:
+  version: "9.1.6"

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,411 @@
+---
+layout: default
+title: Database Adapters
+nav_order: 3
+---
+
+# Database Adapters
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+The SQL Testing Library supports multiple database engines through adapters. Each adapter handles the specific SQL dialect, connection management, and data type conversions for its database.
+
+## Supported Databases
+
+| Database | Adapter Class | Required Package | SQL Dialect |
+|----------|---------------|------------------|-------------|
+| BigQuery | `BigQueryAdapter` | `google-cloud-bigquery` | BigQuery Standard SQL |
+| Athena | `AthenaAdapter` | `boto3` | Presto/Trino SQL |
+| Redshift | `RedshiftAdapter` | `psycopg2-binary` | PostgreSQL-based |
+| Trino | `TrinoAdapter` | `trino` | Trino SQL |
+| Snowflake | `SnowflakeAdapter` | `snowflake-connector-python` | Snowflake SQL |
+
+## BigQuery Adapter
+
+### Installation
+
+```bash
+pip install sql-testing-library[bigquery]
+```
+
+### Configuration
+
+```ini
+[sql_testing.bigquery]
+project_id = my-gcp-project
+dataset_id = test_dataset
+credentials_path = /path/to/service-account.json
+# Optional: use application default credentials
+# Leave credentials_path empty to use ADC
+```
+
+### Features
+
+- **CTE Creation**: Uses UNION ALL pattern for compatibility with complex data types
+- **Array Support**: Full support for ARRAY types using `[element1, element2]` syntax
+- **Decimal Handling**: Automatic conversion for NUMERIC/DECIMAL types
+- **Query Limits**: ~1MB for CTE mode before switching to physical tables
+
+### Database Context
+
+BigQuery uses project and dataset: `project_id.dataset_id`
+
+```python
+class MyMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "my-project.my_dataset"
+```
+
+### Example
+
+```python
+from decimal import Decimal
+from datetime import date
+
+@dataclass
+class Transaction:
+    id: int
+    amount: Decimal
+    date: date
+    tags: List[str]
+
+# BigQuery handles arrays and decimals natively
+transactions = TransactionsMockTable([
+    Transaction(1, Decimal("99.99"), date(2024, 1, 1), ["online", "credit"]),
+    Transaction(2, Decimal("149.50"), date(2024, 1, 2), ["store", "debit"])
+])
+```
+
+## Athena Adapter
+
+### Installation
+
+```bash
+pip install sql-testing-library[athena]
+```
+
+### Configuration
+
+```ini
+[sql_testing.athena]
+database = test_database
+s3_output_location = s3://my-athena-results/
+region = us-west-2
+# Optional AWS credentials (uses boto3 defaults if not specified)
+aws_access_key_id = YOUR_KEY
+aws_secret_access_key = YOUR_SECRET
+```
+
+### Features
+
+- **S3 Integration**: Results stored in S3
+- **Presto SQL**: Uses Presto/Trino SQL dialect
+- **Query Limits**: 256KB limit for CTE mode
+- **External Tables**: Physical tables backed by S3 data
+
+### Database Context
+
+Athena uses single database name: `database`
+
+```python
+class MyMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "my_database"
+```
+
+### Important Notes
+
+- **S3 Cleanup**: When using physical tables, table metadata is cleaned but S3 data files remain
+- **IAM Permissions**: Requires S3 read/write and Athena query permissions
+- **Cost**: Queries are billed by data scanned
+
+## Redshift Adapter
+
+### Installation
+
+```bash
+pip install sql-testing-library[redshift]
+```
+
+### Configuration
+
+```ini
+[sql_testing.redshift]
+host = my-cluster.region.redshift.amazonaws.com
+database = test_db
+user = redshift_user
+password = redshift_password
+port = 5439  # Optional, defaults to 5439
+```
+
+### Features
+
+- **PostgreSQL Compatible**: Based on PostgreSQL 8.0.2
+- **Temporary Tables**: Automatic cleanup at session end
+- **Array Support**: Via JSON parsing
+- **Query Limits**: 16MB limit for CTE mode
+- **Column Store**: Optimized for analytical queries
+
+### Database Context
+
+Redshift uses single database name: `database`
+
+```python
+class MyMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "my_database"
+```
+
+### Best Practices
+
+- Use distribution keys for large test tables
+- Consider sort keys for time-series data
+- Temporary tables are session-scoped
+
+## Trino Adapter
+
+### Installation
+
+```bash
+pip install sql-testing-library[trino]
+```
+
+### Configuration
+
+```ini
+[sql_testing.trino]
+host = trino.example.com
+port = 8080
+user = trino_user
+catalog = memory  # Default catalog
+schema = default  # Default schema
+http_scheme = http  # or https
+
+# Authentication options:
+# Basic auth
+auth_type = basic
+password = my_password
+
+# JWT auth
+# auth_type = jwt
+# token = eyJhbGc...
+```
+
+### Features
+
+- **Memory Catalog**: Default testing catalog
+- **Multi-Catalog**: Can query across catalogs
+- **Distributed**: Scales across cluster
+- **Query Limits**: ~16MB for CTE mode
+
+### Database Context
+
+Trino uses catalog and schema: `catalog.schema`
+
+```python
+class MyMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "memory.default"
+```
+
+### Testing Tips
+
+- Memory catalog is ideal for testing (no persistence)
+- Can test cross-catalog joins
+- Supports complex analytical functions
+
+## Snowflake Adapter
+
+### Installation
+
+```bash
+pip install sql-testing-library[snowflake]
+```
+
+### Configuration
+
+```ini
+[sql_testing.snowflake]
+account = my-account.us-west-2
+user = snowflake_user
+password = snowflake_password
+database = TEST_DB
+schema = PUBLIC
+warehouse = COMPUTE_WH
+role = DEVELOPER  # Optional
+```
+
+### Features
+
+- **Case Sensitivity**: Column names normalized to lowercase
+- **Temporary Tables**: Session-scoped cleanup
+- **Semi-Structured**: JSON/VARIANT support (limited)
+- **Query Limits**: 1MB for CTE mode
+- **Time Travel**: Can query historical data
+
+### Database Context
+
+Snowflake uses database and schema: `database.schema`
+
+```python
+class MyMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "test_db.public"  # lowercase recommended
+```
+
+### Known Limitations
+
+- Physical table mode has visibility issues in tests
+- Complex types (VARIANT, OBJECT) not fully supported
+- Case sensitivity requires careful handling
+
+## Choosing an Adapter
+
+### Default Adapter Configuration
+
+The adapter specified in the `[sql_testing]` section of your configuration file acts as the default for all tests:
+
+```ini
+[sql_testing]
+adapter = snowflake  # All tests will use Snowflake by default
+
+[sql_testing.snowflake]
+account = my-account
+user = my_user
+# ... other Snowflake settings
+```
+
+When you don't specify an `adapter_type` in your `@sql_test` decorator or `TestCase`, the library uses this default adapter.
+
+### For your tests
+
+You can override the default adapter for specific tests:
+
+```python
+@sql_test(
+    adapter_type="bigquery",  # Override default adapter
+    mock_tables=[...],
+    result_class=ResultClass
+)
+def test_bigquery_specific():
+    return TestCase(...)
+```
+
+### Default adapter
+
+Set in `pytest.ini`:
+
+```ini
+[sql_testing]
+adapter = redshift  # Default for all tests
+```
+
+## Data Type Support by Adapter
+
+### Primitive Types
+
+| Type | BigQuery | Athena | Redshift | Trino | Snowflake |
+|------|----------|---------|----------|-------|-----------|
+| String | ✅ STRING | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR |
+| Integer | ✅ INT64 | ✅ BIGINT | ✅ INTEGER | ✅ BIGINT | ✅ NUMBER |
+| Float | ✅ FLOAT64 | ✅ DOUBLE | ✅ REAL | ✅ DOUBLE | ✅ FLOAT |
+| Boolean | ✅ BOOL | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN |
+| Date | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE |
+| Datetime | ✅ DATETIME | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP |
+| Decimal | ✅ NUMERIC | ✅ DECIMAL | ✅ DECIMAL | ✅ DECIMAL | ✅ NUMBER |
+
+### Array Types
+
+| Type | BigQuery | Athena | Redshift | Trino | Snowflake |
+|------|----------|---------|----------|-------|-----------|
+| String Array | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY |
+| Int Array | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY |
+| Decimal Array | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY |
+
+## Adapter-Specific SQL
+
+### BigQuery
+
+```sql
+-- Arrays
+SELECT ARRAY[1, 2, 3] as numbers
+
+-- Structs
+SELECT STRUCT(1 as id, 'Alice' as name) as user
+
+-- Window functions
+SELECT *, ROW_NUMBER() OVER (PARTITION BY category) as rn
+FROM products
+```
+
+### Athena/Trino
+
+```sql
+-- Arrays with UNNEST
+SELECT * FROM UNNEST(ARRAY[1, 2, 3]) AS t(number)
+
+-- Maps
+SELECT MAP(ARRAY['a', 'b'], ARRAY[1, 2]) as my_map
+
+-- Lambdas
+SELECT FILTER(ARRAY[1, 2, 3, 4], x -> x > 2) as filtered
+```
+
+### Redshift
+
+```sql
+-- JSON arrays
+SELECT JSON_PARSE('[1, 2, 3]') as numbers
+
+-- Window functions
+SELECT *, RANK() OVER (ORDER BY sales DESC) as rank
+FROM sales_data
+
+-- COPY command (not supported in tests)
+```
+
+### Snowflake
+
+```sql
+-- Semi-structured data
+SELECT PARSE_JSON('{"name": "Alice"}') as user_data
+
+-- Flatten arrays
+SELECT VALUE FROM TABLE(FLATTEN(INPUT => ARRAY_CONSTRUCT(1, 2, 3)))
+
+-- Time travel
+SELECT * FROM users AT(TIMESTAMP => '2024-01-01'::TIMESTAMP)
+```
+
+## Troubleshooting
+
+### Connection Issues
+
+1. **BigQuery**: Check service account permissions and project access
+2. **Athena**: Verify S3 permissions and AWS credentials
+3. **Redshift**: Check security groups and network access
+4. **Trino**: Ensure correct authentication method
+5. **Snowflake**: Verify account identifier format
+
+### Query Failures
+
+- Check SQL dialect differences
+- Verify data types match database expectations
+- Look for case sensitivity issues (especially Snowflake)
+- Check query size limits for CTE mode
+
+### Performance
+
+- Use physical tables for large datasets
+- Consider partitioning strategies
+- Monitor query costs (BigQuery, Athena)
+- Use appropriate warehouse size (Snowflake)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,528 @@
+---
+layout: default
+title: API Reference
+nav_order: 4
+---
+
+# API Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Core Classes
+
+### SQLTestCase
+
+A dataclass that represents a SQL test case configuration.
+
+```python
+from sql_testing_library import SQLTestCase, TestCase  # TestCase is an alias
+
+@dataclass
+class SQLTestCase(Generic[T]):
+    query: str
+    default_namespace: Optional[str] = None
+    mock_tables: Optional[List[BaseMockTable]] = None
+    result_class: Optional[Type[T]] = None
+    use_physical_tables: bool = False
+    description: Optional[str] = None
+    adapter_type: Optional[AdapterType] = None
+    execution_database: Optional[str] = None  # Deprecated
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | The SQL query to test |
+| `default_namespace` | `Optional[str]` | Database/schema context for unqualified table names |
+| `mock_tables` | `Optional[List[BaseMockTable]]` | Mock tables with test data |
+| `result_class` | `Optional[Type[T]]` | Class for deserializing results (dataclass/Pydantic) |
+| `use_physical_tables` | `bool` | Force physical tables instead of CTEs (default: False) |
+| `description` | `Optional[str]` | Optional test description |
+| `adapter_type` | `Optional[AdapterType]` | Override default database adapter |
+
+#### Example
+
+```python
+test_case = TestCase(
+    query="SELECT * FROM users WHERE active = true",
+    default_namespace="my_dataset",
+    mock_tables=[users_mock],
+    result_class=UserResult
+)
+```
+
+### BaseMockTable
+
+Abstract base class for creating mock tables with test data.
+
+```python
+from sql_testing_library.mock_table import BaseMockTable
+
+class BaseMockTable(ABC):
+    def __init__(self, data: Optional[List[Any]] = None):
+        self.data = data or []
+
+    @abstractmethod
+    def get_database_name(self) -> str:
+        """Return the database/schema name"""
+        pass
+
+    @abstractmethod
+    def get_table_name(self) -> str:
+        """Return the table name"""
+        pass
+```
+
+#### Abstract Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get_database_name()` | `str` | Database/schema name for the mock table |
+| `get_table_name()` | `str` | Table name |
+
+#### Provided Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get_qualified_name()` | `str` | Fully qualified table name |
+| `get_column_types()` | `Dict[str, Type]` | Infer column types from data |
+| `to_dataframe()` | `pd.DataFrame` | Convert to pandas DataFrame |
+| `get_cte_alias()` | `str` | CTE alias for query generation |
+
+#### Example Implementation
+
+```python
+@dataclass
+class Product:
+    id: int
+    name: str
+    price: Decimal
+    tags: List[str]
+
+class ProductsMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "ecommerce.public"
+
+    def get_table_name(self) -> str:
+        return "products"
+
+# Usage
+products = ProductsMockTable([
+    Product(1, "Laptop", Decimal("999.99"), ["electronics", "computers"]),
+    Product(2, "Mouse", Decimal("29.99"), ["electronics", "accessories"])
+])
+```
+
+### SQLTestFramework
+
+The main framework class for executing SQL tests.
+
+```python
+from sql_testing_library import SQLTestFramework
+
+class SQLTestFramework:
+    def __init__(self, adapter: DatabaseAdapter):
+        """Initialize with a database adapter"""
+        self.adapter = adapter
+
+    def run_test(self, test_case: SQLTestCase[T]) -> List[T]:
+        """Execute test case and return typed results"""
+```
+
+#### Methods
+
+| Method | Parameters | Returns | Description |
+|--------|------------|---------|-------------|
+| `__init__` | `adapter: DatabaseAdapter` | None | Initialize framework |
+| `run_test` | `test_case: SQLTestCase[T]` | `List[T]` | Execute test and return results |
+
+#### Example
+
+```python
+from sql_testing_library.adapters import BigQueryAdapter
+
+# Create framework
+adapter = BigQueryAdapter(project_id="my-project", dataset_id="test")
+framework = SQLTestFramework(adapter)
+
+# Run test
+results = framework.run_test(test_case)
+```
+
+## Decorators
+
+### @sql_test
+
+The main decorator for pytest integration. This decorator automatically adds a `sql_test` pytest marker to your test functions.
+
+```python
+from sql_testing_library import sql_test
+
+@sql_test(
+    mock_tables: Optional[List[BaseMockTable]] = None,
+    result_class: Optional[Type[T]] = None,
+    use_physical_tables: Optional[bool] = None,
+    adapter_type: Optional[AdapterType] = None
+)
+```
+
+#### Pytest Marker
+
+Tests decorated with `@sql_test` are automatically marked with the `sql_test` pytest marker, allowing you to:
+
+```bash
+# Run only SQL tests
+pytest -m sql_test
+
+# Exclude SQL tests
+pytest -m "not sql_test"
+
+# Combine with other markers
+pytest -m "sql_test and not slow"
+```
+
+#### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `mock_tables` | `Optional[List[BaseMockTable]]` | Override mock tables |
+| `result_class` | `Optional[Type[T]]` | Override result class |
+| `use_physical_tables` | `Optional[bool]` | Override physical tables flag |
+| `adapter_type` | `Optional[AdapterType]` | Override adapter type |
+
+#### Usage Patterns
+
+```python
+# Pattern 1: All config in decorator
+@sql_test(
+    mock_tables=[users_mock],
+    result_class=UserResult
+)
+def test_users():
+    return TestCase(
+        query="SELECT * FROM users",
+        default_namespace="test_db"
+    )
+
+# Pattern 2: All config in TestCase
+@sql_test()
+def test_users():
+    return TestCase(
+        query="SELECT * FROM users",
+        default_namespace="test_db",
+        mock_tables=[users_mock],
+        result_class=UserResult
+    )
+
+# Pattern 3: Override adapter
+@sql_test(adapter_type="bigquery")
+def test_bigquery_specific():
+    return TestCase(...)
+```
+
+## Database Adapters
+
+### DatabaseAdapter (Abstract Base)
+
+Base class for all database adapters.
+
+```python
+from sql_testing_library.adapters import DatabaseAdapter
+
+class DatabaseAdapter(ABC):
+    @abstractmethod
+    def get_sqlglot_dialect(self) -> str:
+        """Return sqlglot dialect name"""
+
+    @abstractmethod
+    def execute_query(self, query: str) -> pd.DataFrame:
+        """Execute query and return results"""
+
+    @abstractmethod
+    def create_temp_table(self, mock_table: BaseMockTable) -> str:
+        """Create temporary table from mock data"""
+
+    @abstractmethod
+    def cleanup_temp_tables(self, table_names: List[str]) -> None:
+        """Clean up temporary tables"""
+
+    @abstractmethod
+    def format_value_for_cte(self, value: Any, column_type: type) -> str:
+        """Format value for CTE generation"""
+```
+
+### Concrete Adapters
+
+#### BigQueryAdapter
+
+```python
+from sql_testing_library.adapters import BigQueryAdapter
+
+adapter = BigQueryAdapter(
+    project_id: str,
+    dataset_id: str,
+    credentials_path: Optional[str] = None,
+    client: Optional[bigquery.Client] = None
+)
+```
+
+#### AthenaAdapter
+
+```python
+from sql_testing_library.adapters import AthenaAdapter
+
+adapter = AthenaAdapter(
+    database: str,
+    s3_output_location: str,
+    region: Optional[str] = None,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None
+)
+```
+
+#### RedshiftAdapter
+
+```python
+from sql_testing_library.adapters import RedshiftAdapter
+
+adapter = RedshiftAdapter(
+    host: str,
+    database: str,
+    user: str,
+    password: str,
+    port: int = 5439
+)
+```
+
+#### TrinoAdapter
+
+```python
+from sql_testing_library.adapters import TrinoAdapter
+
+adapter = TrinoAdapter(
+    host: str,
+    port: int = 8080,
+    user: str,
+    catalog: str = "memory",
+    schema: str = "default",
+    http_scheme: str = "http",
+    auth: Optional[Authentication] = None
+)
+```
+
+#### SnowflakeAdapter
+
+```python
+from sql_testing_library.adapters import SnowflakeAdapter
+
+adapter = SnowflakeAdapter(
+    account: str,
+    user: str,
+    password: str,
+    database: str,
+    schema: str = "PUBLIC",
+    warehouse: str,
+    role: Optional[str] = None
+)
+```
+
+## Exceptions
+
+All exceptions inherit from `SQLTestingError`.
+
+### Exception Hierarchy
+
+```python
+SQLTestingError
+├── MockTableNotFoundError
+├── SQLParseError
+├── QuerySizeLimitExceeded
+└── TypeConversionError
+```
+
+### MockTableNotFoundError
+
+Raised when a required mock table is not provided.
+
+```python
+from sql_testing_library.exceptions import MockTableNotFoundError
+
+try:
+    framework.run_test(test_case)
+except MockTableNotFoundError as e:
+    print(f"Missing mock table: {e}")
+```
+
+### SQLParseError
+
+Raised when SQL parsing fails.
+
+```python
+from sql_testing_library.exceptions import SQLParseError
+
+try:
+    framework.run_test(test_case)
+except SQLParseError as e:
+    print(f"Invalid SQL: {e}")
+```
+
+### QuerySizeLimitExceeded
+
+Raised when CTE query exceeds database size limits.
+
+```python
+from sql_testing_library.exceptions import QuerySizeLimitExceeded
+
+# Library automatically falls back to physical tables
+# or you can handle manually:
+try:
+    framework.run_test(test_case)
+except QuerySizeLimitExceeded:
+    test_case.use_physical_tables = True
+    framework.run_test(test_case)
+```
+
+### TypeConversionError
+
+Raised during result deserialization.
+
+```python
+from sql_testing_library.exceptions import TypeConversionError
+
+try:
+    results = framework.run_test(test_case)
+except TypeConversionError as e:
+    print(f"Type mismatch: {e}")
+```
+
+## Type System
+
+### Supported Python Types
+
+| Python Type | SQL Type Support | Notes |
+|-------------|------------------|-------|
+| `str` | VARCHAR/STRING | Universal support |
+| `int` | INTEGER/BIGINT | 64-bit integers |
+| `float` | FLOAT/DOUBLE | Double precision |
+| `bool` | BOOLEAN | True/False |
+| `date` | DATE | From datetime module |
+| `datetime` | TIMESTAMP | With timezone support |
+| `Decimal` | DECIMAL/NUMERIC | Arbitrary precision |
+| `None` | NULL | Null values |
+| `List[T]` | ARRAY | Arrays of supported types |
+| `Optional[T]` | Nullable | Union[T, None] |
+
+### Type Conversion
+
+The library automatically handles type conversions between Python and SQL:
+
+```python
+from decimal import Decimal
+from datetime import date, datetime
+from typing import List, Optional
+
+@dataclass
+class ComplexData:
+    id: int
+    amount: Decimal
+    created_at: datetime
+    tags: List[str]
+    notes: Optional[str]
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `SQL_TESTING_PROJECT_ROOT` | Override config file search path | `/path/to/project` |
+
+### Configuration Files
+
+The library searches for configuration in this order:
+1. `pytest.ini`
+2. `setup.cfg`
+3. `tox.ini`
+
+### Configuration Sections
+
+```ini
+[sql_testing]
+adapter = bigquery  # Default adapter
+
+[sql_testing.bigquery]
+# BigQuery-specific settings
+
+[sql_testing.athena]
+# Athena-specific settings
+
+# ... other adapters
+```
+
+## Advanced Usage
+
+### Custom Type Converters
+
+Extend type conversion for custom types:
+
+```python
+class MyCustomType:
+    def __init__(self, value: str):
+        self.value = value
+
+    def to_sql_value(self) -> str:
+        return f"'{self.value}'"
+```
+
+### Dynamic Mock Tables
+
+Generate mock data programmatically:
+
+```python
+class DynamicMockTable(BaseMockTable):
+    def __init__(self, row_count: int):
+        data = [
+            {"id": i, "value": f"test_{i}"}
+            for i in range(row_count)
+        ]
+        super().__init__(data)
+```
+
+### Testing CTEs
+
+Test individual CTEs in complex queries:
+
+```python
+@sql_test(mock_tables=[base_table])
+def test_cte_logic():
+    return TestCase(
+        query="""
+        WITH aggregated AS (
+            SELECT category, SUM(amount) as total
+            FROM transactions
+            GROUP BY category
+        )
+        SELECT * FROM aggregated WHERE total > 100
+        """,
+        default_namespace="test_db",
+        result_class=CategoryTotal
+    )
+```
+
+## Best Practices
+
+1. **Use Type Hints**: Always specify result_class for type safety
+2. **Mock Realistically**: Use production-like data structures
+3. **Test Edge Cases**: Include nulls, empty arrays, boundary values
+4. **Organize Tests**: Group related tests in classes
+5. **Document Complex Queries**: Add descriptions to test cases
+6. **Version Control**: Track schema changes in mock tables

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,0 +1,281 @@
+/* Custom styles for SQL Testing Library documentation */
+
+/* Code blocks */
+.highlight pre {
+  background-color: #f6f8fa;
+  border: 1px solid #e1e4e8;
+  border-radius: 6px;
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+}
+
+.highlight pre code {
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+  font-size: 100%;
+}
+
+/* Dark mode code blocks */
+.dark-mode .highlight pre {
+  background-color: #161b22;
+  border-color: #30363d;
+}
+
+/* Tables */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+table th {
+  background-color: #f6f8fa;
+  font-weight: 600;
+  text-align: left;
+  padding: 12px;
+  border: 1px solid #e1e4e8;
+}
+
+table td {
+  padding: 12px;
+  border: 1px solid #e1e4e8;
+}
+
+table tr:nth-child(even) {
+  background-color: #f6f8fa;
+}
+
+/* Dark mode tables */
+.dark-mode table th {
+  background-color: #161b22;
+  border-color: #30363d;
+}
+
+.dark-mode table td {
+  border-color: #30363d;
+}
+
+.dark-mode table tr:nth-child(even) {
+  background-color: #0d1117;
+}
+
+/* Cards for documentation links */
+.card {
+  display: block;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  background-color: #f6f8fa;
+  border: 1px solid #e1e4e8;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #0366d6;
+}
+
+.card p {
+  margin: 0;
+  color: #586069;
+}
+
+/* Dark mode cards */
+.dark-mode .card {
+  background-color: #161b22;
+  border-color: #30363d;
+}
+
+.dark-mode .card h3 {
+  color: #58a6ff;
+}
+
+.dark-mode .card p {
+  color: #8b949e;
+}
+
+/* Grid layout for cards */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+/* Callouts */
+.callout {
+  padding: 1rem;
+  margin: 1rem 0;
+  border-left: 4px solid;
+  border-radius: 4px;
+}
+
+.callout-info {
+  background-color: #e3f2fd;
+  border-color: #2196f3;
+}
+
+.callout-warning {
+  background-color: #fff3cd;
+  border-color: #ffc107;
+}
+
+.callout-danger {
+  background-color: #f8d7da;
+  border-color: #dc3545;
+}
+
+.callout-success {
+  background-color: #d4edda;
+  border-color: #28a745;
+}
+
+/* Dark mode callouts */
+.dark-mode .callout-info {
+  background-color: #0d47a1;
+  border-color: #2196f3;
+}
+
+.dark-mode .callout-warning {
+  background-color: #5d4037;
+  border-color: #ffc107;
+}
+
+.dark-mode .callout-danger {
+  background-color: #5d1f1f;
+  border-color: #dc3545;
+}
+
+.dark-mode .callout-success {
+  background-color: #1b5e20;
+  border-color: #28a745;
+}
+
+/* Buttons */
+.btn-primary {
+  background-color: #0366d6;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  text-decoration: none;
+  display: inline-block;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+}
+
+.btn-primary:hover {
+  background-color: #0256c7;
+  text-decoration: none;
+  color: white;
+}
+
+/* Navigation improvements */
+.nav-list .nav-list-item .nav-list-link:hover {
+  background-color: #f6f8fa;
+}
+
+.dark-mode .nav-list .nav-list-item .nav-list-link:hover {
+  background-color: #161b22;
+}
+
+/* Improve readability */
+.main-content {
+  max-width: 1000px;
+}
+
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4,
+.main-content h5,
+.main-content h6 {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.main-content p {
+  line-height: 1.6;
+}
+
+/* Syntax highlighting improvements */
+.highlight .k,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr,
+.highlight .kt {
+  color: #d73a49;
+  font-weight: 600;
+}
+
+.highlight .s,
+.highlight .s1,
+.highlight .s2,
+.highlight .sb,
+.highlight .sc,
+.highlight .sd,
+.highlight .se,
+.highlight .sh,
+.highlight .si,
+.highlight .sr,
+.highlight .ss {
+  color: #032f62;
+}
+
+.highlight .c,
+.highlight .c1,
+.highlight .cm {
+  color: #6a737d;
+  font-style: italic;
+}
+
+/* Copy button for code blocks */
+.code-copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+  background-color: #f6f8fa;
+  border: 1px solid #e1e4e8;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.highlight:hover .code-copy-button {
+  opacity: 1;
+}
+
+.code-copy-button:hover {
+  background-color: #e1e4e8;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  table {
+    font-size: 14px;
+  }
+
+  .main-content {
+    padding: 1rem;
+  }
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,607 @@
+---
+layout: default
+title: Examples
+nav_order: 5
+---
+
+# Examples
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Basic Examples
+
+### Simple Query Test
+
+Testing a basic SELECT query with filtering:
+
+```python
+from dataclasses import dataclass
+from sql_testing_library import sql_test, TestCase
+from sql_testing_library.mock_table import BaseMockTable
+from pydantic import BaseModel
+
+@dataclass
+class Employee:
+    id: int
+    name: str
+    department: str
+    salary: float
+    active: bool
+
+class EmployeesMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "company_db"
+
+    def get_table_name(self) -> str:
+        return "employees"
+
+class ActiveEmployeeResult(BaseModel):
+    name: str
+    department: str
+
+@sql_test(
+    mock_tables=[
+        EmployeesMockTable([
+            Employee(1, "Alice", "Engineering", 100000, True),
+            Employee(2, "Bob", "Sales", 80000, False),
+            Employee(3, "Charlie", "Engineering", 95000, True),
+            Employee(4, "Diana", "HR", 85000, True)
+        ])
+    ],
+    result_class=ActiveEmployeeResult
+)
+def test_active_employees():
+    return TestCase(
+        query="""
+            SELECT name, department
+            FROM employees
+            WHERE active = true
+            ORDER BY name
+        """,
+        default_namespace="company_db"
+    )
+```
+
+### JOIN Query Test
+
+Testing queries with multiple tables:
+
+```python
+@dataclass
+class Order:
+    order_id: int
+    user_id: int
+    product_id: int
+    quantity: int
+    total: float
+
+@dataclass
+class Product:
+    product_id: int
+    name: str
+    category: str
+    price: float
+
+class OrdersMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "sales_db"
+
+    def get_table_name(self) -> str:
+        return "orders"
+
+class ProductsMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "sales_db"
+
+    def get_table_name(self) -> str:
+        return "products"
+
+class OrderDetailResult(BaseModel):
+    order_id: int
+    product_name: str
+    quantity: int
+    total: float
+
+@sql_test(
+    mock_tables=[
+        OrdersMockTable([
+            Order(1, 101, 1, 2, 39.98),
+            Order(2, 102, 2, 1, 999.99),
+            Order(3, 101, 3, 3, 89.97)
+        ]),
+        ProductsMockTable([
+            Product(1, "Mouse", "Electronics", 19.99),
+            Product(2, "Laptop", "Electronics", 999.99),
+            Product(3, "Notebook", "Stationery", 29.99)
+        ])
+    ],
+    result_class=OrderDetailResult
+)
+def test_order_details():
+    return TestCase(
+        query="""
+            SELECT
+                o.order_id,
+                p.name as product_name,
+                o.quantity,
+                o.total
+            FROM orders o
+            JOIN products p ON o.product_id = p.product_id
+            WHERE o.total > 50
+            ORDER BY o.order_id
+        """,
+        default_namespace="sales_db"
+    )
+```
+
+## Advanced Examples
+
+### Working with Arrays
+
+Testing queries with array data types:
+
+```python
+from typing import List
+from decimal import Decimal
+
+@dataclass
+class Customer:
+    customer_id: int
+    name: str
+    tags: List[str]
+    purchase_amounts: List[Decimal]
+
+class CustomersMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "analytics.customer_data"
+
+    def get_table_name(self) -> str:
+        return "customers"
+
+class CustomerTagResult(BaseModel):
+    name: str
+    tag_count: int
+    total_purchases: Decimal
+
+@sql_test(
+    mock_tables=[
+        CustomersMockTable([
+            Customer(
+                1,
+                "Alice",
+                ["vip", "frequent", "email"],
+                [Decimal("99.99"), Decimal("149.50"), Decimal("79.99")]
+            ),
+            Customer(
+                2,
+                "Bob",
+                ["new"],
+                [Decimal("29.99")]
+            ),
+            Customer(
+                3,
+                "Charlie",
+                ["vip", "phone"],
+                [Decimal("299.99"), Decimal("199.99")]
+            )
+        ])
+    ],
+    result_class=CustomerTagResult
+)
+def test_customer_analytics():
+    return TestCase(
+        query="""
+            SELECT
+                name,
+                ARRAY_LENGTH(tags) as tag_count,
+                (SELECT SUM(amount) FROM UNNEST(purchase_amounts) as amount) as total_purchases
+            FROM customers
+            WHERE 'vip' IN UNNEST(tags)
+            ORDER BY name
+        """,
+        default_namespace="analytics.customer_data"
+    )
+```
+
+### Date and Time Operations
+
+Working with temporal data:
+
+```python
+from datetime import date, datetime
+
+@dataclass
+class Event:
+    event_id: int
+    event_name: str
+    event_date: date
+    created_at: datetime
+    duration_hours: float
+
+class EventsMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "events_db"
+
+    def get_table_name(self) -> str:
+        return "events"
+
+class EventSummaryResult(BaseModel):
+    month: str
+    event_count: int
+    total_hours: float
+
+@sql_test(
+    mock_tables=[
+        EventsMockTable([
+            Event(1, "Conference", date(2024, 1, 15), datetime(2024, 1, 1, 10, 30), 8.0),
+            Event(2, "Workshop", date(2024, 1, 20), datetime(2024, 1, 5, 14, 0), 4.0),
+            Event(3, "Seminar", date(2024, 2, 10), datetime(2024, 2, 1, 9, 0), 3.0),
+            Event(4, "Training", date(2024, 2, 25), datetime(2024, 2, 15, 13, 30), 6.0)
+        ])
+    ],
+    result_class=EventSummaryResult
+)
+def test_event_summary():
+    return TestCase(
+        query="""
+            SELECT
+                FORMAT_DATE('%Y-%m', event_date) as month,
+                COUNT(*) as event_count,
+                SUM(duration_hours) as total_hours
+            FROM events
+            WHERE event_date >= '2024-01-01'
+            GROUP BY month
+            ORDER BY month
+        """,
+        default_namespace="events_db"
+    )
+```
+
+### Window Functions
+
+Testing analytical queries with window functions:
+
+```python
+@dataclass
+class Sale:
+    sale_id: int
+    salesperson: str
+    region: str
+    amount: Decimal
+    sale_date: date
+
+class SalesMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "sales_analytics"
+
+    def get_table_name(self) -> str:
+        return "sales"
+
+class SalesRankResult(BaseModel):
+    salesperson: str
+    region: str
+    amount: Decimal
+    region_rank: int
+    total_rank: int
+
+@sql_test(
+    mock_tables=[
+        SalesMockTable([
+            Sale(1, "Alice", "North", Decimal("5000"), date(2024, 1, 1)),
+            Sale(2, "Bob", "North", Decimal("7000"), date(2024, 1, 2)),
+            Sale(3, "Charlie", "South", Decimal("6000"), date(2024, 1, 3)),
+            Sale(4, "Diana", "South", Decimal("8000"), date(2024, 1, 4)),
+            Sale(5, "Eve", "North", Decimal("4500"), date(2024, 1, 5))
+        ])
+    ],
+    result_class=SalesRankResult
+)
+def test_sales_ranking():
+    return TestCase(
+        query="""
+            SELECT
+                salesperson,
+                region,
+                amount,
+                RANK() OVER (PARTITION BY region ORDER BY amount DESC) as region_rank,
+                RANK() OVER (ORDER BY amount DESC) as total_rank
+            FROM sales
+            WHERE sale_date >= '2024-01-01'
+            ORDER BY total_rank
+        """,
+        default_namespace="sales_analytics"
+    )
+```
+
+## Database-Specific Examples
+
+### BigQuery-Specific Features
+
+Using BigQuery SQL features in your queries (note: the library creates CTEs using UNION ALL, not STRUCT):
+
+```python
+# BigQuery adapter test
+@sql_test(
+    adapter_type="bigquery",
+    mock_tables=[products_mock],
+    result_class=dict
+)
+def test_bigquery_structs():
+    return TestCase(
+        query="""
+            SELECT
+                STRUCT(
+                    product_id as id,
+                    name,
+                    ARRAY[
+                        STRUCT('color' as attribute, 'red' as value),
+                        STRUCT('size' as attribute, 'large' as value)
+                    ] as attributes
+                ) as product_info
+            FROM products
+            WHERE category = 'Electronics'
+        """,
+        default_namespace="my-project.my_dataset"
+    )
+```
+
+### Athena/Trino Array Operations
+
+Using Presto/Trino SQL array functions:
+
+```python
+# Athena adapter test
+@sql_test(
+    adapter_type="athena",
+    mock_tables=[events_mock],
+    result_class=dict
+)
+def test_athena_arrays():
+    return TestCase(
+        query="""
+            SELECT
+                event_name,
+                CARDINALITY(attendees) as attendee_count,
+                FILTER(attendees, x -> x LIKE '%@company.com') as company_attendees
+            FROM events
+            WHERE CONTAINS(attendees, 'alice@company.com')
+        """,
+        default_namespace="analytics_db"
+    )
+```
+
+### Redshift JSON Handling
+
+Working with JSON in Redshift:
+
+```python
+# Redshift adapter test
+@sql_test(
+    adapter_type="redshift",
+    mock_tables=[user_events_mock],
+    result_class=dict
+)
+def test_redshift_json():
+    return TestCase(
+        query="""
+            SELECT
+                user_id,
+                JSON_EXTRACT_PATH_TEXT(event_data, 'action') as action,
+                JSON_EXTRACT_PATH_TEXT(event_data, 'timestamp')::timestamp as event_time
+            FROM user_events
+            WHERE JSON_EXTRACT_PATH_TEXT(event_data, 'action') = 'purchase'
+        """,
+        default_namespace="events_db"
+    )
+```
+
+## Testing Patterns
+
+### Testing CTEs
+
+Breaking down complex queries:
+
+```python
+@sql_test(
+    mock_tables=[transactions_mock, customers_mock],
+    result_class=CustomerMetricsResult
+)
+def test_customer_metrics():
+    return TestCase(
+        query="""
+            WITH monthly_totals AS (
+                SELECT
+                    customer_id,
+                    DATE_TRUNC('month', transaction_date) as month,
+                    SUM(amount) as monthly_total
+                FROM transactions
+                GROUP BY customer_id, month
+            ),
+            customer_stats AS (
+                SELECT
+                    customer_id,
+                    AVG(monthly_total) as avg_monthly_spend,
+                    MAX(monthly_total) as max_monthly_spend,
+                    COUNT(DISTINCT month) as active_months
+                FROM monthly_totals
+                GROUP BY customer_id
+            )
+            SELECT
+                c.name,
+                cs.avg_monthly_spend,
+                cs.max_monthly_spend,
+                cs.active_months
+            FROM customer_stats cs
+            JOIN customers c ON cs.customer_id = c.customer_id
+            WHERE cs.active_months >= 3
+            ORDER BY cs.avg_monthly_spend DESC
+        """,
+        default_namespace="analytics_db"
+    )
+```
+
+### Testing Error Cases
+
+Validating business logic:
+
+```python
+@sql_test(
+    mock_tables=[
+        InventoryMockTable([
+            {"product_id": 1, "quantity": 5, "min_stock": 10},
+            {"product_id": 2, "quantity": 15, "min_stock": 10},
+            {"product_id": 3, "quantity": 0, "min_stock": 5}
+        ])
+    ],
+    result_class=LowStockAlert
+)
+def test_low_stock_alerts():
+    return TestCase(
+        query="""
+            SELECT
+                product_id,
+                quantity,
+                min_stock,
+                CASE
+                    WHEN quantity = 0 THEN 'OUT_OF_STOCK'
+                    WHEN quantity < min_stock THEN 'LOW_STOCK'
+                    ELSE 'NORMAL'
+                END as stock_status
+            FROM inventory
+            WHERE quantity < min_stock
+            ORDER BY quantity ASC
+        """,
+        default_namespace="inventory_db"
+    )
+```
+
+### Dynamic Test Generation
+
+Creating parameterized tests:
+
+```python
+import pytest
+
+test_cases = [
+    ("North", 2),  # region, expected_count
+    ("South", 1),
+    ("East", 0)
+]
+
+@pytest.mark.parametrize("region,expected_count", test_cases)
+def test_sales_by_region(region, expected_count):
+    @sql_test(
+        mock_tables=[
+            SalesMockTable([
+                Sale(1, "Alice", "North", 5000, date(2024, 1, 1)),
+                Sale(2, "Bob", "North", 7000, date(2024, 1, 2)),
+                Sale(3, "Charlie", "South", 6000, date(2024, 1, 3))
+            ])
+        ],
+        result_class=dict
+    )
+    def _test():
+        return TestCase(
+            query=f"""
+                SELECT COUNT(*) as count
+                FROM sales
+                WHERE region = '{region}'
+            """,
+            default_namespace="sales_db"
+        )
+
+    results = _test()
+    assert results[0]['count'] == expected_count
+```
+
+## Best Practices
+
+### 1. Organize Mock Tables
+
+Create a separate module for mock tables:
+
+```python
+# tests/mocks/tables.py
+from sql_testing_library.mock_table import BaseMockTable
+
+class BaseCompanyMockTable(BaseMockTable):
+    """Base class for all company mock tables"""
+    def get_database_name(self) -> str:
+        return "company_db.public"
+
+class UsersMockTable(BaseCompanyMockTable):
+    def get_table_name(self) -> str:
+        return "users"
+
+class OrdersMockTable(BaseCompanyMockTable):
+    def get_table_name(self) -> str:
+        return "orders"
+```
+
+### 2. Reusable Test Data
+
+Create factory functions for test data:
+
+```python
+# tests/factories.py
+from datetime import date, timedelta
+from decimal import Decimal
+
+def create_test_orders(count: int, start_date: date):
+    """Generate test orders with sequential dates"""
+    return [
+        Order(
+            order_id=i,
+            user_id=100 + (i % 5),
+            amount=Decimal(str(50 + i * 10)),
+            order_date=start_date + timedelta(days=i)
+        )
+        for i in range(1, count + 1)
+    ]
+```
+
+### 3. Test Complex Business Logic
+
+Focus on testing SQL logic, not just syntax:
+
+```python
+@sql_test(
+    mock_tables=[
+        OrdersMockTable(create_test_orders(100, date(2024, 1, 1))),
+        CustomersMockTable(create_test_customers())
+    ],
+    result_class=CustomerLTVResult
+)
+def test_customer_lifetime_value():
+    """Test LTV calculation includes all business rules"""
+    return TestCase(
+        query=load_sql_file("queries/customer_ltv.sql"),
+        default_namespace="analytics_db",
+        description="Verify LTV calculation handles refunds, discounts, and loyalty tiers"
+    )
+```
+
+### 4. Document Expected Results
+
+Make tests self-documenting:
+
+```python
+def test_quarterly_revenue():
+    """
+    Test quarterly revenue aggregation.
+
+    Expected results:
+    - Q1 2024: $15,000 (3 orders)
+    - Q2 2024: $22,000 (4 orders)
+    - Excludes cancelled orders
+    - Applies regional tax rates
+    """
+    # Test implementation...
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,303 @@
+---
+layout: default
+title: Getting Started
+nav_order: 2
+---
+
+# Getting Started
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Installation
+
+The SQL Testing Library supports multiple database backends. Install only what you need:
+
+### Install with specific database support
+
+```bash
+# For BigQuery
+pip install sql-testing-library[bigquery]
+
+# For Athena
+pip install sql-testing-library[athena]
+
+# For Redshift
+pip install sql-testing-library[redshift]
+
+# For Trino
+pip install sql-testing-library[trino]
+
+# For Snowflake
+pip install sql-testing-library[snowflake]
+```
+
+### Install with all database adapters
+
+```bash
+pip install sql-testing-library[all]
+```
+
+### Development installation
+
+If you're contributing to the library:
+
+```bash
+# Clone the repository
+git clone https://github.com/gurmeetsaran/sqltesting.git
+cd sqltesting
+
+# Install with poetry
+poetry install --with bigquery,athena,redshift,trino,snowflake,dev
+```
+
+## Configuration
+
+The library uses pytest configuration files to manage database connections. Create a `pytest.ini` file in your project root:
+
+### Basic configuration
+
+```ini
+[sql_testing]
+adapter = bigquery  # Choose: bigquery, athena, redshift, trino, or snowflake
+```
+
+### Database-specific configuration
+
+#### BigQuery
+
+```ini
+[sql_testing.bigquery]
+project_id = my-test-project
+dataset_id = test_dataset
+credentials_path = path/to/service-account-key.json
+```
+
+#### Athena
+
+```ini
+[sql_testing.athena]
+database = test_database
+s3_output_location = s3://my-athena-results/
+region = us-west-2
+# Optional: if not using default AWS credentials
+aws_access_key_id = YOUR_ACCESS_KEY
+aws_secret_access_key = YOUR_SECRET_KEY
+```
+
+#### Redshift
+
+```ini
+[sql_testing.redshift]
+host = redshift-cluster.region.redshift.amazonaws.com
+database = test_database
+user = redshift_user
+password = redshift_password
+port = 5439  # Optional, defaults to 5439
+```
+
+#### Trino
+
+```ini
+[sql_testing.trino]
+host = trino-server.example.com
+port = 8080  # Optional, defaults to 8080
+user = trino_user
+catalog = memory  # Optional, defaults to 'memory'
+schema = default  # Optional, defaults to 'default'
+http_scheme = http  # Optional, use 'https' for secure connections
+
+# For Basic Authentication:
+auth_type = basic
+password = trino_password
+
+# For JWT Authentication:
+# auth_type = jwt
+# token = your_jwt_token
+```
+
+#### Snowflake
+
+```ini
+[sql_testing.snowflake]
+account = account-identifier
+user = snowflake_user
+password = snowflake_password
+database = test_database
+schema = PUBLIC  # Optional, defaults to 'PUBLIC'
+warehouse = compute_wh  # Required
+role = my_role  # Optional
+```
+
+## Writing Your First Test
+
+### 1. Create a mock table
+
+```python
+from dataclasses import dataclass
+from sql_testing_library.mock_table import BaseMockTable
+
+@dataclass
+class User:
+    user_id: int
+    name: str
+    email: str
+    active: bool
+
+class UsersMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "test_db"  # Your test database/dataset
+
+    def get_table_name(self) -> str:
+        return "users"
+```
+
+### 2. Write a test with the @sql_test decorator
+
+```python
+from sql_testing_library import sql_test, TestCase
+from pydantic import BaseModel
+
+# Define result model
+class ActiveUserResult(BaseModel):
+    user_id: int
+    name: str
+
+# Create test
+@sql_test(
+    mock_tables=[
+        UsersMockTable([
+            User(1, "Alice", "alice@example.com", True),
+            User(2, "Bob", "bob@example.com", False),
+            User(3, "Charlie", "charlie@example.com", True)
+        ])
+    ],
+    result_class=ActiveUserResult
+)
+def test_active_users():
+    return TestCase(
+        query="""
+            SELECT user_id, name
+            FROM users
+            WHERE active = true
+            ORDER BY user_id
+        """,
+        default_namespace="test_db"
+    )
+```
+
+### 3. Run your test
+
+```bash
+# Run all tests
+pytest test_users.py
+
+# Run only SQL tests (using the sql_test marker)
+pytest -m sql_test
+
+# Exclude SQL tests from your test run
+pytest -m "not sql_test"
+
+# Run a specific test
+pytest test_users.py::test_active_users -v
+
+# With poetry
+poetry run pytest test_users.py
+
+# Combine markers with other pytest options
+pytest -m sql_test -v --tb=short
+```
+
+**Note**: The `@sql_test` decorator automatically adds a pytest marker to your tests, making it easy to run or exclude SQL tests from your test suite.
+
+## Understanding the Basics
+
+### Mock Tables
+
+Mock tables represent your database tables with test data:
+
+- Inherit from `BaseMockTable`
+- Implement `get_database_name()` and `get_table_name()`
+- Pass data as a list of dataclasses, dictionaries, or objects
+
+### Test Cases
+
+The `TestCase` class defines your SQL test:
+
+- `query`: The SQL query to test
+- `default_namespace`: Database context for unqualified table names
+- `mock_tables`: List of mock tables (can be in decorator or TestCase)
+- `result_class`: Class for deserializing results (dataclass or Pydantic)
+
+### Result Classes
+
+Define expected results using:
+
+- Python dataclasses
+- Pydantic models
+- Dict (for simple key-value results)
+
+## Common Patterns
+
+### Pattern 1: All configuration in decorator
+
+```python
+@sql_test(
+    mock_tables=[users_mock, orders_mock],
+    result_class=OrderSummary
+)
+def test_order_summary():
+    return TestCase(
+        query="SELECT * FROM orders JOIN users ON orders.user_id = users.id",
+        default_namespace="test_db"
+    )
+```
+
+### Pattern 2: All configuration in TestCase
+
+```python
+@sql_test()  # Empty decorator
+def test_order_summary():
+    return TestCase(
+        query="SELECT * FROM orders JOIN users ON orders.user_id = users.id",
+        default_namespace="test_db",
+        mock_tables=[users_mock, orders_mock],
+        result_class=OrderSummary
+    )
+```
+
+### Pattern 3: Using physical tables for large datasets
+
+```python
+@sql_test(
+    mock_tables=[large_dataset_mock],
+    result_class=ResultClass,
+    use_physical_tables=True  # Force physical tables
+)
+def test_large_dataset():
+    return TestCase(
+        query="SELECT * FROM large_table",
+        default_namespace="test_db"
+    )
+```
+
+## Next Steps
+
+- [Learn about database adapters](adapters)
+- [Explore advanced examples](examples)
+- [Read the API reference](api-reference)
+- [Troubleshooting guide](troubleshooting)
+
+## Quick Tips
+
+1. **Start Simple**: Begin with basic queries and gradually add complexity
+2. **Use Type Hints**: Leverage dataclasses and Pydantic for type safety
+3. **Test Incrementally**: Test individual CTEs and subqueries separately
+4. **Mock Realistically**: Use representative test data that matches production schemas
+5. **Check Query Plans**: Use `EXPLAIN` to understand how your queries execute

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,196 @@
+---
+layout: default
+title: SQL Testing Library
+nav_order: 1
+description: "A Python library for testing SQL queries with mock data injection across multiple database platforms"
+permalink: /
+---
+
+# SQL Testing Library
+{: .fs-9 }
+
+A Python library for testing SQL queries with mock data injection across Athena, BigQuery, Redshift, Trino, and Snowflake.
+{: .fs-6 .fw-300 }
+
+[Get started now](getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 } [View on GitHub](https://github.com/gurmeetsaran/sqltesting){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## 🎯 Why SQL Testing Library?
+
+SQL testing in data engineering can be challenging, especially when working with large datasets and complex queries across multiple database platforms. This library addresses the pain points of:
+
+- **Fragile Integration Tests**: Traditional tests that depend on live data break when data changes
+- **Slow Feedback Loops**: Running tests against full datasets takes too long for CI/CD
+- **Database Engine Upgrades**: UDF semantics and SQL behavior change between database versions, causing silent production failures
+- **Database Lock-in**: Tests written for one database don't work on another
+- **Complex Setup**: Each database requires different mocking strategies and tooling
+
+## ✨ Key Features
+
+### 🚀 Multi-Database Support
+Test your SQL queries across BigQuery, Athena, Redshift, Trino, and Snowflake with a unified API.
+
+### 🎯 Type-Safe Testing
+Use Python dataclasses and Pydantic models for type-safe test data and results.
+
+### ⚡ Flexible Execution
+Automatically switches between CTE injection and physical tables based on query size.
+
+### 🧪 Pytest Integration
+Seamlessly integrates with pytest using the `@sql_test` decorator.
+
+### 📊 Comprehensive Type Support
+Supports primitive types, arrays, decimals, dates, and optional values across all databases.
+
+## 📋 Quick Example
+
+```python
+from dataclasses import dataclass
+from sql_testing_library import sql_test, TestCase
+from sql_testing_library.mock_table import BaseMockTable
+from pydantic import BaseModel
+
+@dataclass
+class User:
+    user_id: int
+    name: str
+    email: str
+
+class UserResult(BaseModel):
+    user_id: int
+    name: str
+
+class UsersMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "test_db"
+
+    def get_table_name(self) -> str:
+        return "users"
+
+@sql_test(
+    mock_tables=[
+        UsersMockTable([
+            User(1, "Alice", "alice@example.com"),
+            User(2, "Bob", "bob@example.com")
+        ])
+    ],
+    result_class=UserResult
+)
+def test_user_query():
+    return TestCase(
+        query="SELECT user_id, name FROM users WHERE user_id = 1",
+        default_namespace="test_db"
+    )
+```
+
+## 🏗️ Supported Databases
+
+| Database | CTE Mode | Physical Tables | Query Size Limit |
+|----------|----------|-----------------|------------------|
+| **BigQuery** | ✅ | ✅ | ~1MB |
+| **Athena** | ✅ | ✅ | 256KB |
+| **Redshift** | ✅ | ✅ | 16MB |
+| **Trino** | ✅ | ✅ | ~16MB |
+| **Snowflake** | ✅ | ⚠️* | 1MB |
+
+*Physical tables in Snowflake currently have limitations in test environments.
+
+### Data Types Support
+
+✅ **Supported Types**: String, Integer, Float, Boolean, Date, Datetime, Decimal, Arrays, Optional/Nullable types
+
+❌ **Not Yet Supported**:
+- Struct/Record types (nested objects)
+- Map/Object types (key-value pairs)
+- Nested Arrays (arrays of arrays)
+- JSON Objects (semi-structured data)
+
+## 📚 Documentation
+
+<div class="grid">
+  <div class="col-4 col-md-4 col-lg-4">
+    <a href="getting-started" class="card">
+      <div class="card-body">
+        <h3>Getting Started</h3>
+        <p>Installation, configuration, and your first test</p>
+      </div>
+    </a>
+  </div>
+  <div class="col-4 col-md-4 col-lg-4">
+    <a href="adapters" class="card">
+      <div class="card-body">
+        <h3>Database Adapters</h3>
+        <p>Configure and use different database engines</p>
+      </div>
+    </a>
+  </div>
+  <div class="col-4 col-md-4 col-lg-4">
+    <a href="api-reference" class="card">
+      <div class="card-body">
+        <h3>API Reference</h3>
+        <p>Complete reference for all classes and methods</p>
+      </div>
+    </a>
+  </div>
+</div>
+
+## 🚀 Getting Started
+
+### Installation
+
+```bash
+# Install with specific database support
+pip install sql-testing-library[bigquery]
+pip install sql-testing-library[athena]
+pip install sql-testing-library[redshift]
+pip install sql-testing-library[trino]
+pip install sql-testing-library[snowflake]
+
+# Or install with all database adapters
+pip install sql-testing-library[all]
+```
+
+### Configuration
+
+Create a `pytest.ini` file in your project root:
+
+```ini
+[sql_testing]
+adapter = bigquery  # Choose your database
+
+[sql_testing.bigquery]
+project_id = my-test-project
+dataset_id = test_dataset
+credentials_path = path/to/credentials.json
+```
+
+### Write Your First Test
+
+```python
+@sql_test
+def test_simple_query():
+    return TestCase(
+        query="SELECT 1 as value",
+        result_class=dict
+    )
+```
+
+## 🤝 Contributing
+
+Contributions are welcome! Please check out our [Contributing Guide](https://github.com/gurmeetsaran/sqltesting/blob/master/CONTRIBUTING.md) for details.
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/gurmeetsaran/sqltesting/blob/master/LICENSE) file for details.
+
+## 🙏 Acknowledgments
+
+Built with ❤️ by the data engineering community. Special thanks to all [contributors](https://github.com/gurmeetsaran/sqltesting/graphs/contributors).
+
+---
+
+<div class="text-center">
+  <a href="https://github.com/gurmeetsaran/sqltesting" class="btn btn-outline">View on GitHub</a>
+  <a href="https://pypi.org/project/sql-testing-library/" class="btn btn-outline">View on PyPI</a>
+</div>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,372 @@
+---
+layout: default
+title: Troubleshooting
+nav_order: 6
+---
+
+# Troubleshooting
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Common Issues
+
+### Configuration Not Found
+
+**Error**: `No [sql_testing] section found in pytest.ini, setup.cfg, or tox.ini`
+
+**Causes**:
+- IDE running tests from wrong directory
+- Configuration file in wrong location
+- Missing configuration file
+
+**Solutions**:
+
+1. **Set environment variable**:
+   ```bash
+   export SQL_TESTING_PROJECT_ROOT=/path/to/project
+   ```
+
+2. **Create conftest.py** in project root:
+   ```python
+   import os
+   import pytest
+
+   def pytest_configure(config):
+       if not os.environ.get('SQL_TESTING_PROJECT_ROOT'):
+           project_root = os.path.dirname(os.path.abspath(__file__))
+           os.environ['SQL_TESTING_PROJECT_ROOT'] = project_root
+   ```
+
+3. **Check working directory** in IDE settings
+
+### Mock Table Not Found
+
+**Error**: `MockTableNotFoundError: Mock table 'users' not found`
+
+**Causes**:
+- Table name mismatch
+- Database/schema name mismatch
+- Case sensitivity issues
+
+**Solutions**:
+
+1. **Verify table names match**:
+   ```python
+   # In mock table
+   def get_table_name(self) -> str:
+       return "users"  # Must match SQL query
+
+   # In SQL query
+   SELECT * FROM users  # Table name must match
+   ```
+
+2. **Check database context**:
+   ```python
+   # Mock table database
+   def get_database_name(self) -> str:
+       return "test_db"
+
+   # TestCase namespace
+   default_namespace="test_db"  # Must match
+   ```
+
+### Query Size Limit Exceeded
+
+**Error**: `QuerySizeLimitExceeded: Query exceeds 256KB limit`
+
+**Automatic handling**: Library switches to physical tables
+
+**Manual solutions**:
+
+1. **Force physical tables**:
+   ```python
+   @sql_test(use_physical_tables=True)
+   def test_large_dataset():
+       return TestCase(...)
+   ```
+
+2. **Reduce test data size**:
+   ```python
+   # Instead of 10,000 rows, use representative sample
+   mock_data = generate_sample_data(100)
+   ```
+
+### Type Conversion Errors
+
+**Error**: `TypeConversionError: Cannot convert 'invalid_date' to date`
+
+**Causes**:
+- Data type mismatch
+- Invalid date/time formats
+- Null handling issues
+
+**Solutions**:
+
+1. **Match Python and SQL types**:
+   ```python
+   from datetime import date, datetime
+   from decimal import Decimal
+
+   @dataclass
+   class Transaction:
+       amount: Decimal  # Not float
+       transaction_date: date  # Not string
+       created_at: datetime  # With timezone
+   ```
+
+2. **Handle nulls properly**:
+   ```python
+   from typing import Optional
+
+   @dataclass
+   class User:
+       email: Optional[str]  # Can be None/NULL
+   ```
+
+### Database Connection Issues
+
+#### BigQuery
+
+**Error**: `google.auth.exceptions.DefaultCredentialsError`
+
+**Solutions**:
+1. Set credentials path:
+   ```ini
+   [sql_testing.bigquery]
+   credentials_path = /path/to/service-account.json
+   ```
+
+2. Use application default credentials:
+   ```bash
+   gcloud auth application-default login
+   ```
+
+#### Athena
+
+**Error**: `botocore.exceptions.NoCredentialsError`
+
+**Solutions**:
+1. Configure AWS credentials:
+   ```ini
+   [sql_testing.athena]
+   aws_access_key_id = YOUR_KEY
+   aws_secret_access_key = YOUR_SECRET
+   ```
+
+2. Use AWS CLI:
+   ```bash
+   aws configure
+   ```
+
+#### Redshift
+
+**Error**: `psycopg2.OperationalError: FATAL: password authentication failed`
+
+**Solutions**:
+1. Verify credentials
+2. Check network/firewall access
+3. Ensure security group allows connections
+
+#### Snowflake
+
+**Error**: `snowflake.connector.errors.DatabaseError: Invalid account identifier`
+
+**Solutions**:
+1. Use correct account format:
+   ```ini
+   [sql_testing.snowflake]
+   account = xy12345.us-west-2  # Include region
+   ```
+
+### Array Type Issues
+
+**Error**: Arrays not working as expected
+
+**Database-specific solutions**:
+
+1. **BigQuery**:
+   ```python
+   # NULL arrays become empty arrays
+   tags: List[str] = field(default_factory=list)
+   ```
+
+2. **Redshift**:
+   ```python
+   # Arrays via JSON
+   tags: List[str]  # Stored as JSON string
+   ```
+
+3. **Athena/Trino**:
+   ```sql
+   -- Use UNNEST for array operations
+   SELECT * FROM UNNEST(array_column) AS t(value)
+   ```
+
+## Performance Issues
+
+### Slow Test Execution
+
+**Causes**:
+- Large datasets in CTE mode
+- Network latency
+- Inefficient queries
+
+**Solutions**:
+
+1. **Use physical tables for large data**:
+   ```python
+   @sql_test(use_physical_tables=True)
+   ```
+
+2. **Optimize test data**:
+   ```python
+   # Generate only necessary data
+   def create_minimal_test_data():
+       return [row for row in data if row.is_relevant]
+   ```
+
+3. **Run tests in parallel**:
+   ```bash
+   pytest -n auto  # Requires pytest-xdist
+   ```
+
+### Memory Issues
+
+**Error**: `MemoryError` or slow performance
+
+**Solutions**:
+
+1. **Stream large results**:
+   ```python
+   # Process results in chunks
+   for chunk in pd.read_sql(query, con, chunksize=1000):
+       process_chunk(chunk)
+   ```
+
+2. **Limit result size**:
+   ```sql
+   SELECT * FROM large_table LIMIT 1000
+   ```
+
+## Debugging Tips
+
+### Enable Verbose Output
+
+```bash
+# See generated SQL
+pytest -v -s test_file.py
+
+# With captured output
+pytest --capture=no
+```
+
+### Inspect Generated CTE
+
+```python
+@sql_test(mock_tables=[...])
+def test_debug():
+    test_case = TestCase(
+        query="SELECT * FROM users",
+        default_namespace="test_db"
+    )
+
+    # Print generated query
+    print(test_case.query)
+    return test_case
+```
+
+### Check Adapter Configuration
+
+```python
+from sql_testing_library._pytest_plugin import SQLTestDecorator
+
+decorator = SQLTestDecorator()
+config = decorator._get_adapter_config("bigquery")
+print(config)
+```
+
+## Platform-Specific Issues
+
+### GitHub Actions
+
+**Issue**: Tests pass locally but fail in CI
+
+**Solutions**:
+1. Use same Python version
+2. Set timezone: `TZ=UTC`
+3. Check secret/environment variables
+
+### Docker
+
+**Issue**: Configuration not found in container
+
+**Solutions**:
+1. Mount config file:
+   ```dockerfile
+   COPY pytest.ini /app/pytest.ini
+   ```
+
+2. Set environment:
+   ```dockerfile
+   ENV SQL_TESTING_PROJECT_ROOT=/app
+   ```
+
+## Getting Help
+
+### Resources
+
+1. [GitHub Issues](https://github.com/gurmeetsaran/sqltesting/issues)
+2. [Discussions](https://github.com/gurmeetsaran/sqltesting/discussions)
+3. [Stack Overflow](https://stackoverflow.com/questions/tagged/sql-testing-library)
+
+### Debug Information
+
+When reporting issues, include:
+
+```python
+import sys
+import sql_testing_library
+
+print(f"Python: {sys.version}")
+print(f"Library: {sql_testing_library.__version__}")
+print(f"Platform: {sys.platform}")
+
+# Adapter versions
+try:
+    import google.cloud.bigquery
+    print(f"BigQuery: {google.cloud.bigquery.__version__}")
+except ImportError:
+    pass
+```
+
+### Minimal Reproducible Example
+
+```python
+# test_minimal.py
+from sql_testing_library import sql_test, TestCase
+from sql_testing_library.mock_table import BaseMockTable
+
+class MinimalMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "test_db"
+
+    def get_table_name(self) -> str:
+        return "test_table"
+
+@sql_test(
+    mock_tables=[MinimalMockTable([{"id": 1}])],
+    result_class=dict
+)
+def test_minimal():
+    return TestCase(
+        query="SELECT * FROM test_table",
+        default_namespace="test_db"
+    )
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,34 @@ name = "sql-testing-library"
 version = "0.5.0"
 description = "A Python library for testing SQL queries with mock data injection"
 authors = ["Gurmeet Saran <gurmeetx@gmail.com>"]
+maintainers = ["Gurmeet Saran <gurmeetx@gmail.com>", "Kushal Thakkar <kushal.thakkar@gmail.com>"]
+license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/gurmeetsaran/sqltesting"
+repository = "https://github.com/gurmeetsaran/sqltesting"
+documentation = "https://github.com/gurmeetsaran/sqltesting#readme"
+keywords = ["sql", "testing", "mock", "database", "bigquery", "snowflake", "redshift", "athena", "trino"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Database",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Typing :: Typed",
+]
 packages = [{include = "sql_testing_library", from = "src"}]
+include = ["LICENSE", "README.md", "CHANGELOG.md", "py.typed"]
+
+[tool.poetry.urls]
+"Bug Tracker" = "https://github.com/gurmeetsaran/sqltesting/issues"
+"Changelog" = "https://github.com/gurmeetsaran/sqltesting/blob/master/CHANGELOG.md"
+"Discussions" = "https://github.com/gurmeetsaran/sqltesting/discussions"
 
 [tool.poetry.dependencies]
 python = ">=3.9"
@@ -152,48 +178,48 @@ concurrency = ["thread", "multiprocessing"]
 exclude_lines = [
     # Manual exclusion
     "pragma: no cover",
-    
+
     # Don't complain about missing debug-only code
     "def __repr__",
     "if self\\.debug:",
     "if settings\\.DEBUG",
-    
+
     # Don't complain if tests don't hit defensive assertion code
     "raise AssertionError",
     "raise NotImplementedError",
     "raise ImportError",
     "raise ValueError.*unreachable",
-    
+
     # Don't complain if non-runnable code isn't run
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
     "if typing\\.TYPE_CHECKING:",
-    
+
     # Abstract methods and classes
     "@abstract",
     "@abstractmethod",
     "class .*\\bProtocol\\):",
     "class .*\\bAbstract.*\\):",
     "raise NotImplementedError.*",
-    
+
     # Exception handling for optional imports
     "except ImportError:",
     "except ModuleNotFoundError:",
     "HAS_.* = False",
     "HAS_.* = True",
     ".*_module = None",
-    
+
     # Skip empty functions/methods and ellipsis
     "^\\s*pass\\s*$",
     "^\\s*\\.\\.\\.\\s*$",
-    
+
     # Type annotation-only lines
     "^\\s*\\.\\.\\.$",
-    
+
     # Platform specific code that may not be tested
     "if sys\\.platform",
     "if os\\.name",
-    
+
     # Version checks
     "if sys\\.version_info",
 ]

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -17,7 +17,7 @@ poetry install --with dev
 
 # Install the pre-commit hooks
 echo "Installing git hooks..."
-poetry run pre-commit install
+poetry run pre-commit install --hook-type commit-msg
 
 echo "Pre-commit hooks installed successfully!"
 echo "Now your code will be automatically checked and formatted when you commit."


### PR DESCRIPTION
  - Create complete GitHub Pages documentation structure with Jekyll
  - Document pytest marker functionality for running SQL tests with `-m sql_test`
  - Clarify default adapter behavior (defaults to BigQuery if not specified)
  - Add unsupported data types section to clearly show what's not yet supported
  - Correct BigQuery adapter documentation (uses UNION ALL, not STRUCT/UNNEST for CTEs)
  - Fix navigation links and add troubleshooting guide
  - Update Docker instructions for local documentation preview
  - Add custom styling and Jekyll configuration for better readability