### PR TITLE
perf(athena): upgrade sqlglot package to get athena dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The library supports different data types across database engines. All checkmark
 ### Database-Specific Notes
 
 - **BigQuery**: NULL arrays become empty arrays `[]`; uses scientific notation for large decimals
-- **Athena**: 256KB query size limit; uses Presto SQL dialect for arrays
+- **Athena**: 256KB query size limit; uses Athena SQL dialect for arrays
 - **Redshift**: Arrays implemented via JSON parsing; 16MB query size limit
 - **Trino**: Memory catalog for testing; excellent decimal precision
 - **Snowflake**: Column names normalized to lowercase; 1MB query size limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ include = ["LICENSE", "README.md", "CHANGELOG.md", "py.typed"]
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-sqlglot = ">=18.0.0,<19.0.0"
+sqlglot = ">=26.0.0"
 pydantic = ">=2.0.0"
 pandas = ">=1.0.0"
 typing-extensions = {version = ">=4.5.0", python = "<3.10"}

--- a/src/sql_testing_library/_adapters/athena.py
+++ b/src/sql_testing_library/_adapters/athena.py
@@ -75,8 +75,8 @@ class AthenaAdapter(DatabaseAdapter):
             self.client = boto3.client("athena", region_name=region)
 
     def get_sqlglot_dialect(self) -> str:
-        """Return Presto dialect for sqlglot (Athena uses Presto SQL)."""
-        return "presto"
+        """Return Athena dialect for sqlglot."""
+        return "athena"
 
     def execute_query(self, query: str) -> "pd.DataFrame":
         """Execute query and return results as DataFrame."""

--- a/tests/test_athena_adapter.py
+++ b/tests/test_athena_adapter.py
@@ -64,7 +64,7 @@ class TestAthenaAdapter(unittest.TestCase):
             database=self.database,
             s3_output_location=self.s3_output_location,
         )
-        self.assertEqual(adapter.get_sqlglot_dialect(), "presto")
+        self.assertEqual(adapter.get_sqlglot_dialect(), "athena")
 
     def test_execute_query(self, mock_boto3_client):
         """Test query execution."""


### PR DESCRIPTION
  - Upgrade sqlglot dependency from v18 to v26+ for latest SQL dialect support
  - Switch Athena adapter to use native "athena" dialect instead of "presto"
  - Update tests and documentation to reflect the dialect change
