### PR TITLE
docs: add code owner and update relevant metadata for pypi

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS for SQL Testing Library
+#
+# This file defines the individuals or teams responsible for code in this repository.
+# Code owners are automatically requested for review when someone opens a pull request
+# that modifies code that they own.
+#
+# For more information, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owners - all changes in the repository
+* @gurmeetsaran @kushal-thakkar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQL Testing Library
 
-A Python library for testing SQL queries with mock data injection across Athena, BigQuery, Redshift, Trino, and Snowflake.
+A powerful Python framework for unit testing SQL queries with mock data injection across BigQuery, Snowflake, Redshift, Athena, and Trino.
 
 [![Unit Tests](https://github.com/gurmeetsaran/sqltesting/actions/workflows/tests.yaml/badge.svg)](https://github.com/gurmeetsaran/sqltesting/actions/workflows/tests.yaml)
 [![Athena Integration](https://github.com/gurmeetsaran/sqltesting/actions/workflows/athena-integration.yml/badge.svg)](https://github.com/gurmeetsaran/sqltesting/actions/workflows/athena-integration.yml)
@@ -9,6 +9,7 @@ A Python library for testing SQL queries with mock data injection across Athena,
 [![Trino Integration](https://github.com/gurmeetsaran/sqltesting/actions/workflows/trino-integration.yml/badge.svg)](https://github.com/gurmeetsaran/sqltesting/actions/workflows/trino-integration.yml)
 [![Snowflake Integration](https://github.com/gurmeetsaran/sqltesting/actions/workflows/snowflake-integration.yml/badge.svg)](https://github.com/gurmeetsaran/sqltesting/actions/workflows/snowflake-integration.yml)
 [![GitHub license](https://img.shields.io/github/license/gurmeetsaran/sqltesting)](https://github.com/gurmeetsaran/sqltesting/blob/master/LICENSE)
+[![Pepy Total Downloads](https://img.shields.io/pepy/dt/sql-testing-library?label=PyPI%20Downloads)](https://pepy.tech/projects/sql-testing-library)
 [![codecov](https://codecov.io/gh/gurmeetsaran/sqltesting/branch/master/graph/badge.svg?token=CN3G5X5ZA5)](https://codecov.io/gh/gurmeetsaran/sqltesting)
 ![python version](https://img.shields.io/badge/python-3.9%2B-yellowgreen)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,36 +5,67 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "sql-testing-library"
 version = "0.5.0"
-description = "A Python library for testing SQL queries with mock data injection"
-authors = ["Gurmeet Saran <gurmeetx@gmail.com>"]
+description = "A powerful Python framework for unit testing SQL queries across BigQuery, Snowflake, Redshift, Athena, and Trino with mock data"
+authors = ["Gurmeet Saran <gurmeetx@gmail.com>", "Kushal Thakkar <kushal.thakkar@gmail.com>"]
 maintainers = ["Gurmeet Saran <gurmeetx@gmail.com>", "Kushal Thakkar <kushal.thakkar@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/gurmeetsaran/sqltesting"
+homepage = "https://gurmeetsaran.github.io/sqltesting/"
 repository = "https://github.com/gurmeetsaran/sqltesting"
-documentation = "https://github.com/gurmeetsaran/sqltesting#readme"
-keywords = ["sql", "testing", "mock", "database", "bigquery", "snowflake", "redshift", "athena", "trino"]
+documentation = "https://gurmeetsaran.github.io/sqltesting/"
+keywords = [
+    "sql",
+    "testing",
+    "unit-testing",
+    "mock-data",
+    "database-testing",
+    "bigquery",
+    "snowflake",
+    "redshift",
+    "athena",
+    "trino",
+    "data-engineering",
+    "etl-testing",
+    "sql-validation",
+    "query-testing"
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: System Administrators",
     "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Testing :: Unit",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Database",
+    "Topic :: Database :: Database Engines/Servers",
+    "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: OS Independent",
     "Typing :: Typed",
+    "Natural Language :: English",
+    "Environment :: Console",
+    "Framework :: Pytest",
 ]
 packages = [{include = "sql_testing_library", from = "src"}]
-include = ["LICENSE", "README.md", "CHANGELOG.md", "py.typed"]
+include = ["LICENSE", "README.md", "CHANGELOG.md", "py.typed", "src/sql_testing_library/py.typed"]
 
 [tool.poetry.urls]
+"Homepage" = "https://gurmeetsaran.github.io/sqltesting/"
+"Documentation" = "https://gurmeetsaran.github.io/sqltesting/"
+"Repository" = "https://github.com/gurmeetsaran/sqltesting"
 "Bug Tracker" = "https://github.com/gurmeetsaran/sqltesting/issues"
 "Changelog" = "https://github.com/gurmeetsaran/sqltesting/blob/master/CHANGELOG.md"
 "Discussions" = "https://github.com/gurmeetsaran/sqltesting/discussions"
+"Source Code" = "https://github.com/gurmeetsaran/sqltesting"
+"Release Notes" = "https://github.com/gurmeetsaran/sqltesting/releases"
+"Contributing" = "https://github.com/gurmeetsaran/sqltesting/blob/master/CONTRIBUTING.md"
 
 [tool.poetry.dependencies]
 python = ">=3.9"


### PR DESCRIPTION
  - Add CODEOWNERS file in .github/ with maintainers @gurmeetsaran and @kushal-thakkar
  - Enhance PyPI metadata with professional description and comprehensive classifiers
  - Add extensive keywords for better discoverability
  - Include complete URL set (homepage, docs, blog, contributing, etc.)
  - Add PyPI download badge to README
