### PR TITLE
feat(redshift): add support for map datatype for redshift

### DIFF
--- a/.github/workflows/redshift-integration.yml
+++ b/.github/workflows/redshift-integration.yml
@@ -21,6 +21,7 @@ on:
       # Cross-adapter test files
       - 'tests/integration/test_complex_types_integration.py'
       - 'tests/integration/test_primitive_types_integration.py'
+      - 'tests/integration/test_map_types_integration.py'
 
       # Workflow file itself
       - '.github/workflows/redshift-integration.yml'
@@ -40,6 +41,7 @@ on:
       # Cross-adapter test files
       - 'tests/integration/test_complex_types_integration.py'
       - 'tests/integration/test_primitive_types_integration.py'
+      - 'tests/integration/test_map_types_integration.py'
 
       # Workflow file itself
       - '.github/workflows/redshift-integration.yml'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A powerful Python framework for unit testing SQL queries with mock data injectio
 [![Pepy Total Downloads](https://img.shields.io/pepy/dt/sql-testing-library?label=PyPI%20Downloads)](https://pepy.tech/projects/sql-testing-library)
 [![codecov](https://codecov.io/gh/gurmeetsaran/sqltesting/branch/master/graph/badge.svg?token=CN3G5X5ZA5)](https://codecov.io/gh/gurmeetsaran/sqltesting)
 ![python version](https://img.shields.io/badge/python-3.9%2B-yellowgreen)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://gurmeetsaran.github.io/sqltesting/)
 
 ## 🎯 Motivation
 
@@ -78,8 +79,8 @@ The library supports different data types across database engines. All checkmark
 | **Integer Array** | `List[int]` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Decimal Array** | `List[Decimal]` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Optional Array** | `Optional[List[T]]` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Map/Object** | `Dict[K, V]` | ❌ | ✅ | ✅ | ✅ | ❌ |
 | **Struct/Record** | `dict`/`dataclass` | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Map/Object** | `Dict[K, V]` | ❌ | ✅ | ❌ | ✅ | ❌ |
 | **Nested Arrays** | `List[List[T]]` | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **JSON Objects** | `JSON` | ❌ | ❌ | ❌ | ❌ | ❌ |
 
@@ -87,7 +88,7 @@ The library supports different data types across database engines. All checkmark
 
 - **BigQuery**: NULL arrays become empty arrays `[]`; uses scientific notation for large decimals
 - **Athena**: 256KB query size limit; supports arrays and maps using `ARRAY[]` and `MAP(ARRAY[], ARRAY[])` syntax
-- **Redshift**: Arrays implemented via JSON parsing; 16MB query size limit
+- **Redshift**: Arrays and maps implemented via SUPER type (JSON parsing); 16MB query size limit
 - **Trino**: Memory catalog for testing; excellent decimal precision; supports arrays and maps
 - **Snowflake**: Column names normalized to lowercase; 1MB query size limit
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -151,7 +151,8 @@ port = 5439  # Optional, defaults to 5439
 
 - **PostgreSQL Compatible**: Based on PostgreSQL 8.0.2
 - **Temporary Tables**: Automatic cleanup at session end
-- **Array Support**: Via JSON parsing
+- **Array Support**: Via SUPER type (JSON parsing)
+- **Map Support**: Via SUPER type for Dict[K, V] types
 - **Query Limits**: 16MB limit for CTE mode
 - **Column Store**: Optimized for analytical queries
 
@@ -330,9 +331,9 @@ adapter = redshift  # Default for all tests
 | String Array | `List[str]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY |
 | Int Array | `List[int]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY |
 | Decimal Array | `List[Decimal]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY |
-| String Map | `Dict[str, str]` | ❌ | ✅ MAP | ❌ | ✅ MAP | ❌ |
-| Int Map | `Dict[str, int]` | ❌ | ✅ MAP | ❌ | ✅ MAP | ❌ |
-| Mixed Map | `Dict[K, V]` | ❌ | ✅ MAP | ❌ | ✅ MAP | ❌ |
+| String Map | `Dict[str, str]` | ❌ | ✅ MAP | ✅ SUPER | ✅ MAP | ❌ |
+| Int Map | `Dict[str, int]` | ❌ | ✅ MAP | ✅ SUPER | ✅ MAP | ❌ |
+| Mixed Map | `Dict[K, V]` | ❌ | ✅ MAP | ✅ SUPER | ✅ MAP | ❌ |
 
 ## Adapter-Specific SQL
 
@@ -380,8 +381,17 @@ SELECT FILTER(ARRAY[1, 2, 3, 4], x -> x > 2) as filtered
 ### Redshift
 
 ```sql
--- JSON arrays
+-- JSON arrays via SUPER type
 SELECT JSON_PARSE('[1, 2, 3]') as numbers
+
+-- JSON maps via SUPER type
+SELECT JSON_PARSE('{"key1": "value1", "key2": "value2"}') as my_map
+
+-- Accessing SUPER elements
+SELECT
+    my_super_column[0] as first_element,
+    my_super_column.field_name as field_value
+FROM table_with_super
 
 -- Window functions
 SELECT *, RANK() OVER (ORDER BY sales DESC) as rank

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,11 +103,14 @@ def test_user_query():
 
 ✅ **Supported Types**: String, Integer, Float, Boolean, Date, Datetime, Decimal, Arrays, Optional/Nullable types
 
+✅ **Partially Supported Types**:
+- Map/Object types (Dict[K, V]) - Supported in Athena, Trino, and Redshift
+
 ❌ **Not Yet Supported**:
 - Struct/Record types (nested objects)
-- Map/Object types (key-value pairs)
 - Nested Arrays (arrays of arrays)
 - JSON Objects (semi-structured data)
+- Map types in BigQuery and Snowflake
 
 ## 📚 Documentation
 


### PR DESCRIPTION
 Summary of All Changes for Redshift Map Type Support

  1. Core Implementation Changes to support map datatype for redshift using SUPER
  2. Documentation Updates
  - Updated data types table to show Redshift supports Map/Object types
  - Updated database notes: "Redshift: Arrays and maps implemented via SUPER type (JSON parsing)"
  - Added GitHub Pages documentation badge
  - Added Authors section (since PyPI only shows first author)

  3. Key Technical Details

  - SUPER Type: Redshift's semi-structured data type that stores JSON-like data
  - JSON Serialization: Python dicts are converted to JSON strings, then parsed with JSON_PARSE()
  - Key Preservation: Unlike typical JSON, Redshift SUPER preserves integer keys as integers
  - Type Conversion: Added proper handling for Optional[Dict] types in the type converter

  4. Test Coverage

  All map type integration tests now pass for Redshift in both CTE and physical table modes:
  - Basic map types: Dict[str, str], Dict[str, int], Dict[str, Decimal], Dict[int, str]
  - Optional maps: Optional[Dict[str, str]]
  - Empty maps and NULL maps
  - Verified integer keys are preserved (not converted to strings)
