### PR TITLE
feat(bigquery): add support for map in bigquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,13 @@ The library supports different data types across database engines. All checkmark
 | **Integer Array** | `List[int]` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Decimal Array** | `List[Decimal]` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Optional Array** | `Optional[List[T]]` | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Map/Object** | `Dict[K, V]` | ❌ | ✅ | ✅ | ✅ | ❌ |
-| **Struct/Record** | `dict`/`dataclass` | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Map/Dict** | `Dict[K, V]` | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **Struct/Record** | `dataclass` | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Nested Arrays** | `List[List[T]]` | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **JSON Objects** | `JSON` | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Database-Specific Notes
 
-- **BigQuery**: NULL arrays become empty arrays `[]`; uses scientific notation for large decimals
+- **BigQuery**: NULL arrays become empty arrays `[]`; uses scientific notation for large decimals; dict/map types stored as JSON strings
 - **Athena**: 256KB query size limit; supports arrays and maps using `ARRAY[]` and `MAP(ARRAY[], ARRAY[])` syntax
 - **Redshift**: Arrays and maps implemented via SUPER type (JSON parsing); 16MB query size limit
 - **Trino**: Memory catalog for testing; excellent decimal precision; supports arrays and maps

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -210,9 +210,9 @@ def test_customer_analytics():
     )
 ```
 
-### Working with Maps (Athena/Trino/Redshift)
+### Working with Maps (BigQuery/Athena/Trino/Redshift)
 
-Map types are supported for Athena, Trino, and Redshift adapters:
+Map types are supported for BigQuery, Athena, Trino, and Redshift adapters:
 
 ```python
 from typing import Dict, Optional
@@ -277,6 +277,26 @@ test_case = TestCase(
         ORDER BY username
     """,
     default_namespace="analytics"
+)
+
+# BigQuery-specific map query (stored as JSON)
+bigquery_test_case = TestCase(
+    query="""
+        SELECT
+            username,
+            JSON_EXTRACT_SCALAR(settings, '$.theme') as theme_preference,
+            JSON_EXTRACT_SCALAR(settings, '$.notifications') as notifications_enabled,
+            JSON_EXTRACT_SCALAR(metadata, '$.source') as data_source,
+            CASE
+                WHEN metadata IS NULL THEN 'No metadata'
+                WHEN metadata = '{}' THEN 'Empty metadata'
+                ELSE 'Has metadata'
+            END as metadata_status
+        FROM user_preferences
+        WHERE JSON_EXTRACT_SCALAR(settings, '$.theme') IS NOT NULL
+        ORDER BY username
+    """,
+    default_namespace="my-project.analytics"
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,13 +104,12 @@ def test_user_query():
 ✅ **Supported Types**: String, Integer, Float, Boolean, Date, Datetime, Decimal, Arrays, Optional/Nullable types
 
 ✅ **Partially Supported Types**:
-- Map/Object types (Dict[K, V]) - Supported in Athena, Trino, and Redshift
+- Map/Object types (Dict[K, V]) - Supported in BigQuery, Athena, Trino, and Redshift
 
 ❌ **Not Yet Supported**:
 - Struct/Record types (nested objects)
 - Nested Arrays (arrays of arrays)
-- JSON Objects (semi-structured data)
-- Map types in BigQuery and Snowflake
+- Map types in Snowflake
 
 ## 📚 Documentation
 

--- a/src/sql_testing_library/_sql_utils.py
+++ b/src/sql_testing_library/_sql_utils.py
@@ -167,6 +167,9 @@ def format_sql_value(value: Any, column_type: Type, dialect: str = "standard") -
             elif dialect == "redshift":
                 # Redshift SUPER type handles NULL maps
                 return "NULL::SUPER"
+            elif dialect == "bigquery":
+                # BigQuery JSON type handles NULL maps
+                return "NULL"
             else:
                 return "NULL"
 
@@ -289,9 +292,14 @@ def format_sql_value(value: Any, column_type: Type, dialect: str = "standard") -
             # Redshift uses SUPER type with JSON-like syntax for maps
             json_str = json.dumps(value, cls=DecimalEncoder)
             return f"JSON_PARSE('{json_str}')"
+        elif dialect == "bigquery":
+            # BigQuery stores JSON as strings
+            json_str = json.dumps(value, cls=DecimalEncoder)
+            # Escape single quotes in JSON string for SQL
+            json_str = json_str.replace("'", "''")
+            return f"'{json_str}'"
         else:
             # Other databases don't have native map support yet
-            # Could potentially use JSON for BigQuery, Snowflake
             raise NotImplementedError(f"Map type not yet supported for dialect: {dialect}")
 
     # Handle string types

--- a/tests/integration/test_map_types_integration.py
+++ b/tests/integration/test_map_types_integration.py
@@ -61,12 +61,12 @@ class MapTypesMockTable(BaseMockTable):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("adapter_type", ["athena", "trino", "redshift"])
+@pytest.mark.parametrize("adapter_type", ["athena", "trino", "redshift", "bigquery"])
 @pytest.mark.parametrize(
     "use_physical_tables", [False, True], ids=["cte_mode", "physical_tables_mode"]
 )
 class TestMapTypesIntegration:
-    """Integration tests for map types across Athena, Trino, and Redshift adapters."""
+    """Integration tests for map types across Athena, Trino, Redshift, and BigQuery adapters."""
 
     @pytest.fixture(autouse=True)
     def setup_test_data(self, adapter_type):
@@ -113,6 +113,8 @@ class TestMapTypesIntegration:
             self.database_name = "memory"
         elif adapter_type == "redshift":
             self.database_name = "public"
+        elif adapter_type == "bigquery":
+            self.database_name = "test_dataset"
 
     def test_map_types_comprehensive(self, adapter_type, use_physical_tables):
         """Test all map types comprehensively for the specified adapter."""
@@ -150,6 +152,8 @@ class TestMapTypesIntegration:
             self._verify_trino_results(results)
         elif adapter_type == "redshift":
             self._verify_redshift_results(results)
+        elif adapter_type == "bigquery":
+            self._verify_bigquery_results(results)
 
     def _verify_athena_results(self, results):
         """Verify Athena-specific results."""
@@ -236,6 +240,43 @@ class TestMapTypesIntegration:
             "total": Decimal("21.49"),
         }
         # Redshift preserves integer keys in JSON
+        assert row1.mixed_map == {1: "first", 2: "second", 3: "third"}
+        assert row1.optional_string_map == {"optional": "value", "test": "data"}
+        assert row1.optional_int_map == {"a": 100, "b": 200}
+
+        # Verify second row (with nulls)
+        row2 = results[1]
+        assert row2.id == 2
+        assert row2.string_map == {"hello": "world"}
+        assert row2.int_map == {"single": 1}
+        assert row2.decimal_map == {"amount": Decimal("99.99")}
+        assert row2.mixed_map == {10: "ten"}
+        assert row2.optional_string_map is None
+        assert row2.optional_int_map is None
+
+        # Verify third row (with empty maps)
+        row3 = results[2]
+        assert row3.id == 3
+        assert row3.string_map == {}
+        assert row3.int_map == {"zero": 0}
+        assert row3.decimal_map == {}
+        assert row3.mixed_map == {42: "answer"}
+        assert row3.optional_string_map == {}
+        assert row3.optional_int_map == {"value": 42}
+
+    def _verify_bigquery_results(self, results):
+        """Verify BigQuery-specific results."""
+        # Verify first row
+        row1 = results[0]
+        assert row1.id == 1
+        assert row1.string_map == {"key1": "Bigquery", "key2": "maps", "key3": "test"}
+        assert row1.int_map == {"count": 42, "total": 100, "items": 3}
+        assert row1.decimal_map == {
+            "price": Decimal("19.99"),
+            "tax": Decimal("1.50"),
+            "total": Decimal("21.49"),
+        }
+        # BigQuery preserves integer keys in JSON
         assert row1.mixed_map == {1: "first", 2: "second", 3: "third"}
         assert row1.optional_string_map == {"optional": "value", "test": "data"}
         assert row1.optional_int_map == {"a": 100, "b": 200}

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -355,10 +355,14 @@ class TestFormatSQLValue:
             == "JSON_PARSE('{\"price\": 19.99}')"
         )
 
-        # Test that other dialects still raise NotImplementedError
-        with pytest.raises(NotImplementedError, match="Map type not yet supported"):
-            format_sql_value({"a": "b"}, Dict[str, str], "bigquery")
+        # Test BigQuery map formatting (uses JSON string)
+        result = format_sql_value({"a": "b"}, Dict[str, str], "bigquery")
+        assert result == '\'{"a": "b"}\''
 
+        result = format_sql_value({"key": 42}, Dict[str, int], "bigquery")
+        assert result == "'{\"key\": 42}'"
+
+        # Test that other dialects still raise NotImplementedError
         with pytest.raises(NotImplementedError, match="Map type not yet supported"):
             format_sql_value({"a": "b"}, Dict[str, str], "snowflake")
 


### PR DESCRIPTION
 - Add Dict[K, V] support for BigQuery using JSON string storage
  - Update BigQueryAdapter to handle dict types in schema generation
  - Implement dict serialization/deserialization in BigQueryTypeConverter
  - Add JSON string formatting for dict values in SQL utils
  - Update integration tests to include BigQuery in map types testing
  - Update documentation (README.md and GitHub Pages) to reflect BigQuery dict support
  - Clean up complex types table by removing unsupported JSON row

  BigQuery now supports dict types by storing them as JSON strings in STRING columns,
  providing feature parity with Athena, Trino, and Redshift for map/dict datatypes.
