### PR TITLE
feat(athena/trino): add support for struct/ROW types

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ def test_query_full_struct():
 - **Type Safety**: Full type conversion between Python objects and SQL ROW types
 - **NULL Handling**: Proper handling of optional struct fields
 - **WHERE Clause**: Use struct fields in filtering conditions
+- **List of Structs**: Full support for `List[StructType]` with array operations
 
 **SQL Type Mapping:**
 - Python dataclass/Pydantic model → SQL `ROW(field1 type1, field2 type2, ...)`

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -115,6 +115,8 @@ aws_secret_access_key = YOUR_SECRET
 - **Presto SQL**: Uses Presto/Trino SQL dialect
 - **Query Limits**: 256KB limit for CTE mode
 - **External Tables**: Physical tables backed by S3 data
+- **Struct/ROW Types**: Full support for nested structures using dataclasses or Pydantic models
+- **Map Types**: Native MAP support for Dict[K, V] types
 
 ### Database Context
 
@@ -211,6 +213,8 @@ password = my_password
 - **Multi-Catalog**: Can query across catalogs
 - **Distributed**: Scales across cluster
 - **Query Limits**: ~16MB for CTE mode
+- **Struct/ROW Types**: Full support for nested structures using dataclasses or Pydantic models
+- **Map Types**: Native MAP support for Dict[K, V] types
 
 ### Database Context
 
@@ -338,6 +342,8 @@ adapter = redshift  # Default for all tests
 | String Map | `Dict[str, str]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT |
 | Int Map | `Dict[str, int]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT |
 | Mixed Map | `Dict[K, V]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT |
+| Struct | `dataclass` | ❌ | ✅ ROW | ❌ | ✅ ROW | ❌ |
+| Struct | `Pydantic model` | ❌ | ✅ ROW | ❌ | ✅ ROW | ❌ |
 
 ## Adapter-Specific SQL
 
@@ -392,6 +398,21 @@ SELECT FILTER(ARRAY[1, 2, 3, 4], x -> x > 2) as filtered
 -- Python: Dict[str, str] → SQL: MAP(VARCHAR, VARCHAR)
 -- Python: Dict[str, int] → SQL: MAP(VARCHAR, INTEGER/BIGINT)
 -- Python: Dict[int, str] → SQL: MAP(INTEGER/BIGINT, VARCHAR)
+
+-- Struct/ROW types (Athena/Trino only)
+-- Using named fields with dot notation
+SELECT
+    employee.name,
+    employee.address.city,
+    employee.address.zip_code
+FROM employees
+WHERE employee.salary > 100000
+    AND employee.address.state = 'CA'
+
+-- Creating ROW values
+SELECT CAST(ROW('John', 30, ROW('123 Main St', 'NYC', '10001'))
+    AS ROW(name VARCHAR, age INTEGER, address ROW(street VARCHAR, city VARCHAR, zip VARCHAR)))
+    AS person_info
 ```
 
 ### Redshift

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -424,6 +424,8 @@ except TypeConversionError as e:
 | `List[T]` | ARRAY | Arrays of supported types |
 | `Dict[K, V]` | MAP | Maps (Athena/Trino only) |
 | `Optional[T]` | Nullable | Union[T, None] |
+| `dataclass` | STRUCT/ROW | Structs (Athena/Trino only) |
+| `Pydantic model` | STRUCT/ROW | Structs (Athena/Trino only) |
 
 ### Type Conversion
 
@@ -450,6 +452,32 @@ class MapData:
     scores: Dict[str, int]           # MAP(VARCHAR, INTEGER/BIGINT)
     attributes: Dict[int, str]       # MAP(INTEGER/BIGINT, VARCHAR)
     optional_map: Optional[Dict[str, str]]  # Nullable MAP
+
+# Struct types (Athena/Trino only)
+@dataclass
+class Address:
+    street: str
+    city: str
+    zip_code: str
+
+@dataclass
+class Person:
+    name: str
+    age: int
+    address: Address  # Nested struct
+
+# Pydantic models also work
+from pydantic import BaseModel
+
+class AddressPydantic(BaseModel):
+    street: str
+    city: str
+    zip_code: str
+
+class PersonPydantic(BaseModel):
+    name: str
+    age: int
+    address: AddressPydantic
 ```
 
 ## Configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Automatically switches between CTE injection and physical tables based on query 
 Seamlessly integrates with pytest using the `@sql_test` decorator.
 
 ### 📊 Comprehensive Type Support
-Supports primitive types, arrays, decimals, dates, and optional values across all databases.
+Supports primitive types, arrays, decimals, dates, optional values, and struct types (Athena/Trino) across databases.
 
 ### 🔍 SQL Logging & Debugging
 Automatic SQL logging with formatted output, temp table queries, and full error tracebacks for easy debugging.
@@ -101,10 +101,21 @@ def test_user_query():
 
 ### Data Types Support
 
-✅ **Supported Types**: String, Integer, Float, Boolean, Date, Datetime, Decimal, Arrays, Map/Dict types (Dict[K, V]), Optional/Nullable types
+✅ **Supported Types**:
+- String
+- Integer
+- Float
+- Boolean
+- Date
+- Datetime
+- Decimal
+- Arrays
+- Map/Dict types (Dict[K, V])
+- Optional/Nullable types
+- Struct/Record types (Athena/Trino only - using dataclasses or Pydantic models)
 
 ❌ **Not Yet Supported**:
-- Struct/Record types (nested objects)
+- Struct/Record types for BigQuery, Redshift, and Snowflake
 - Nested Arrays (arrays of arrays)
 
 ## 📚 Documentation

--- a/examples/struct_type_example.py
+++ b/examples/struct_type_example.py
@@ -1,0 +1,188 @@
+"""Example demonstrating struct type support in Athena and Trino."""
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import List
+
+from sql_testing_library import TestCase, sql_test
+from sql_testing_library._mock_table import BaseMockTable
+
+
+@dataclass
+class Address:
+    """Nested struct representing an address."""
+
+    street: str
+    city: str
+    state: str
+    zip_code: str
+
+
+@dataclass
+class Employee:
+    """Struct representing an employee."""
+
+    id: int
+    name: str
+    email: str
+    salary: Decimal
+    address: Address
+    is_active: bool = True
+
+
+@dataclass
+class Department:
+    """Data model with struct fields."""
+
+    dept_id: int
+    dept_name: str
+    manager: Employee
+    employees: List[Employee]
+
+
+class DepartmentMockTable(BaseMockTable):
+    """Mock table for departments."""
+
+    def get_database_name(self) -> str:
+        return "test_db"
+
+    def get_table_name(self) -> str:
+        return "departments"
+
+
+def example_struct_queries():
+    """Demonstrate struct type queries."""
+
+    # Create sample data
+    departments = [
+        Department(
+            dept_id=1,
+            dept_name="Engineering",
+            manager=Employee(
+                id=101,
+                name="Alice Johnson",
+                email="alice@company.com",
+                salary=Decimal("120000.00"),
+                address=Address(
+                    street="123 Tech Lane", city="San Francisco", state="CA", zip_code="94105"
+                ),
+                is_active=True,
+            ),
+            employees=[
+                Employee(
+                    id=102,
+                    name="Bob Smith",
+                    email="bob@company.com",
+                    salary=Decimal("95000.00"),
+                    address=Address(
+                        street="456 Code Ave", city="San Francisco", state="CA", zip_code="94107"
+                    ),
+                    is_active=True,
+                ),
+                Employee(
+                    id=103,
+                    name="Charlie Davis",
+                    email="charlie@company.com",
+                    salary=Decimal("85000.00"),
+                    address=Address(
+                        street="789 Dev Road", city="Oakland", state="CA", zip_code="94612"
+                    ),
+                    is_active=True,
+                ),
+            ],
+        )
+    ]
+
+    # Example 1: Query struct fields using dot notation
+    @sql_test(
+        adapter_type="athena",  # or "trino"
+        mock_tables=[DepartmentMockTable(departments)],
+        result_class=dict,
+    )
+    def query_manager_info():
+        return TestCase(
+            query="""
+                SELECT
+                    dept_id,
+                    dept_name,
+                    manager.name AS manager_name,
+                    manager.email AS manager_email,
+                    manager.address.city AS manager_city,
+                    manager.address.state AS manager_state
+                FROM departments
+                WHERE dept_id = 1
+            """,
+            default_namespace="test_db",
+        )
+
+    # Example 2: Query with struct in WHERE clause
+    @sql_test(
+        adapter_type="athena",
+        mock_tables=[DepartmentMockTable(departments)],
+        result_class=dict,
+    )
+    def query_high_salary_managers():
+        return TestCase(
+            query="""
+                SELECT
+                    dept_name,
+                    manager.name AS manager_name,
+                    manager.salary AS salary
+                FROM departments
+                WHERE manager.salary > 100000
+                    AND manager.is_active = TRUE
+            """,
+            default_namespace="test_db",
+        )
+
+    # Example 3: Query entire struct
+    @sql_test(
+        adapter_type="athena",
+        mock_tables=[DepartmentMockTable(departments)],
+        result_class=dict,
+    )
+    def query_full_struct():
+        return TestCase(
+            query="""
+                SELECT
+                    dept_id,
+                    dept_name,
+                    manager
+                FROM departments
+            """,
+            default_namespace="test_db",
+        )
+
+    print("Example 1: Manager information using dot notation")
+    result1 = query_manager_info()
+    for row in result1:
+        print(f"  Department: {row['dept_name']}")
+        print(f"  Manager: {row['manager_name']} ({row['manager_email']})")
+        print(f"  Location: {row['manager_city']}, {row['manager_state']}")
+        print()
+
+    print("Example 2: High salary managers")
+    result2 = query_high_salary_managers()
+    for row in result2:
+        print(f"  {row['manager_name']} - ${row['salary']}")
+        print()
+
+    print("Example 3: Full struct data")
+    result3 = query_full_struct()
+    for row in result3:
+        print(f"  Department {row['dept_id']}: {row['dept_name']}")
+        print(f"  Manager struct: {row['manager']}")
+        print()
+
+
+if __name__ == "__main__":
+    # Note: This example requires a configured Athena or Trino connection
+    # Set appropriate environment variables before running
+    print("Struct Type Support Example")
+    print("=" * 50)
+
+    try:
+        example_struct_queries()
+    except Exception as e:
+        print("Note: To run this example, configure your Athena/Trino connection")
+        print(f"Error: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,8 @@ unfixable = ["T201", "T203"]
 # Allow print statements in test files for debugging and output
 "tests/test_*.py" = ["T201"]
 "tests/*/test_*.py" = ["T201"]
+# Allow print statements in example files
+"examples/*.py" = ["T201"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2

--- a/scripts/manage-redshift-cluster.py
+++ b/scripts/manage-redshift-cluster.py
@@ -18,11 +18,11 @@ Note: The 'destroy' command now automatically removes security group rules that
 """
 
 import argparse
-import json
 import os
 import sys
 import time
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
+
 
 try:
     import boto3
@@ -294,7 +294,7 @@ class RedshiftClusterManager:
                 print(f"❌ Unexpected error: {e}")
                 return False
 
-        print(f"⏰ Timeout waiting for workgroup deletion")
+        print("⏰ Timeout waiting for workgroup deletion")
         return False
 
     def delete_namespace(self, namespace_name: str) -> bool:
@@ -313,7 +313,7 @@ class RedshiftClusterManager:
                 return True
             elif error_code == 'ConflictException':
                 print(f"⚠️  Cannot delete namespace: {e}")
-                print(f"ℹ️  This usually means workgroup is still being deleted. Try waiting longer.")
+                print("ℹ️  This usually means workgroup is still being deleted. Try waiting longer.")
                 return False
             else:
                 print(f"❌ Failed to delete namespace: {e}")
@@ -349,7 +349,7 @@ class RedshiftClusterManager:
                 print(f"❌ Unexpected error: {e}")
                 return False
 
-        print(f"⏰ Timeout waiting for namespace deletion")
+        print("⏰ Timeout waiting for namespace deletion")
         return False
 
     def generate_pytest_config(
@@ -454,7 +454,7 @@ port = {endpoint_info['port']}"""
                     rule.get('ToPort') == 5439 and
                     rule.get('IpProtocol') == 'tcp'):
                     redshift_rule_exists = True
-                    print(f"ℹ️  Redshift port 5439 rule already exists in security group")
+                    print("ℹ️  Redshift port 5439 rule already exists in security group")
                     break
 
             if not redshift_rule_exists:
@@ -480,7 +480,7 @@ port = {endpoint_info['port']}"""
         except ClientError as e:
             error_code = e.response['Error']['Code']
             if error_code == 'InvalidGroup.Duplicate':
-                print(f"ℹ️  Security group rule already exists")
+                print("ℹ️  Security group rule already exists")
             else:
                 print(f"⚠️  Warning: Could not configure security group {security_group_id}: {e}")
         except Exception as e:
@@ -540,7 +540,7 @@ port = {endpoint_info['port']}"""
             if cleanup_success:
                 print(f"✅ Security group cleanup completed for workgroup: {workgroup_name}")
             else:
-                print(f"⚠️  Some security group rules could not be removed")
+                print("⚠️  Some security group rules could not be removed")
             return cleanup_success
 
         except ClientError as e:
@@ -605,7 +605,7 @@ port = {endpoint_info['port']}"""
                 print(f"ℹ️  Security group {security_group_id} not found, skipping rule removal")
                 return True
             elif error_code == 'InvalidGroupId.NotFound':
-                print(f"ℹ️  Security group rule not found, may have been already removed")
+                print("ℹ️  Security group rule not found, may have been already removed")
                 return True
             else:
                 print(f"⚠️  Warning: Could not remove rules from security group {security_group_id}: {e}")
@@ -710,10 +710,10 @@ def main():
 
         # Configure security group for connectivity
         if success:
-            print(f"🔧 Configuring security group for Redshift connectivity...")
+            print("🔧 Configuring security group for Redshift connectivity...")
             if not manager.configure_security_group_for_workgroup(args.workgroup):
-                print(f"⚠️  Warning: Security group configuration failed. You may need to manually configure security groups.")
-                print(f"ℹ️  Required: Allow inbound TCP traffic on port 5439")
+                print("⚠️  Warning: Security group configuration failed. You may need to manually configure security groups.")
+                print("ℹ️  Required: Allow inbound TCP traffic on port 5439")
 
         # Generate config if requested
         if success and args.generate_config:
@@ -727,10 +727,10 @@ def main():
                 )
 
                 print(config)
-                print(f"✅ Sample pytest.ini configuration file")
+                print("✅ Sample pytest.ini configuration file")
 
     elif args.command == "status":
-        print(f"📊 Checking status of Redshift resources")
+        print("📊 Checking status of Redshift resources")
         status = manager.get_status(args.namespace, args.workgroup)
 
         print(f"Namespace ({args.namespace}): {status.get('namespace', 'UNKNOWN')}")
@@ -756,16 +756,16 @@ def main():
                 else:
                     psql_cmd = f"psql -h {endpoint_info['host']} -p {endpoint_info['port']} -U {args.admin_user} -d {args.database}"
 
-                print(f"\n🔗 Manual Connection Commands:")
-                print(f"psql command:")
+                print("\n🔗 Manual Connection Commands:")
+                print("psql command:")
                 print(f"  {psql_cmd}")
 
                 if not args.admin_password:
-                    print(f"\nNote: Set REDSHIFT_ADMIN_PASSWORD environment variable for automatic password inclusion")
+                    print("\nNote: Set REDSHIFT_ADMIN_PASSWORD environment variable for automatic password inclusion")
 
             if args.generate_config:
                 if not args.quiet:
-                    print(f"\n📋 Pytest Configuration:")
+                    print("\n📋 Pytest Configuration:")
                 config = manager.generate_pytest_config(
                     endpoint_info,
                     args.database,
@@ -774,7 +774,7 @@ def main():
                 )
                 if not args.quiet:
                     print(config)
-                    print(f"\n✅ Sample pytest.ini configuration generated")
+                    print("\n✅ Sample pytest.ini configuration generated")
                 else:
                     # In quiet mode, just write the config file
                     with open("pytest.ini", "w") as f:
@@ -791,15 +791,15 @@ def main():
         success = manager.cleanup_security_group_for_workgroup(args.workgroup)
 
     elif args.command == "destroy":
-        print(f"🗑️  Destroying Redshift Serverless resources")
+        print("🗑️  Destroying Redshift Serverless resources")
 
         # First, clean up security group rules while workgroup still exists (unless skipped)
         if not args.skip_sg_cleanup:
-            print(f"🧹 Cleaning up security group rules...")
+            print("🧹 Cleaning up security group rules...")
             if not manager.cleanup_security_group_for_workgroup(args.workgroup):
-                print(f"⚠️  Warning: Security group cleanup failed, but continuing with resource deletion")
+                print("⚠️  Warning: Security group cleanup failed, but continuing with resource deletion")
         else:
-            print(f"ℹ️  Skipping security group cleanup (--skip-sg-cleanup specified)")
+            print("ℹ️  Skipping security group cleanup (--skip-sg-cleanup specified)")
 
         # Delete workgroup first
         if not manager.delete_workgroup(args.workgroup):
@@ -808,7 +808,7 @@ def main():
         # Always wait for workgroup deletion before deleting namespace
         # This is required because namespace deletion will fail if workgroup still exists
         if success:
-            print(f"⏳ Waiting for workgroup deletion to complete (required before namespace deletion)...")
+            print("⏳ Waiting for workgroup deletion to complete (required before namespace deletion)...")
             success = manager.wait_for_workgroup_deletion(args.workgroup)
 
         # Delete namespace only after workgroup is fully deleted
@@ -818,7 +818,7 @@ def main():
 
         # Always wait for namespace deletion to complete (just like workgroup deletion)
         if success:
-            print(f"⏳ Waiting for namespace deletion to complete...")
+            print("⏳ Waiting for namespace deletion to complete...")
             success = manager.wait_for_namespace_deletion(args.namespace)
 
     # Exit with appropriate code

--- a/scripts/validate-redshift-setup.py
+++ b/scripts/validate-redshift-setup.py
@@ -18,6 +18,7 @@ import os
 import sys
 from typing import Dict, Optional
 
+
 try:
     import boto3
     import psycopg2
@@ -62,7 +63,7 @@ def check_aws_connectivity(region: str) -> bool:
         # Test basic AWS connectivity
         sts_client = boto3.client("sts", region_name=region)
         identity = sts_client.get_caller_identity()
-        print(f"  ✅ AWS Authentication successful")
+        print("  ✅ AWS Authentication successful")
         print(f"  ✅ Account ID: {identity.get('Account')}")
         print(f"  ✅ User ARN: {identity.get('Arn')}")
 
@@ -72,12 +73,12 @@ def check_aws_connectivity(region: str) -> bool:
         # Try to list namespaces (this tests read permissions)
         try:
             namespaces = redshift_client.list_namespaces()
-            print(f"  ✅ Redshift Serverless list permissions: OK")
+            print("  ✅ Redshift Serverless list permissions: OK")
             print(f"  ℹ️  Found {len(namespaces.get('namespaces', []))} existing namespaces")
         except ClientError as e:
             if e.response['Error']['Code'] == 'AccessDenied':
-                print(f"  ❌ Redshift Serverless permissions: Access denied")
-                print(f"     Required permissions: redshift-serverless:ListNamespaces")
+                print("  ❌ Redshift Serverless permissions: Access denied")
+                print("     Required permissions: redshift-serverless:ListNamespaces")
                 return False
             else:
                 print(f"  ⚠️  Redshift Serverless API test failed: {e}")
@@ -85,10 +86,10 @@ def check_aws_connectivity(region: str) -> bool:
         return True
 
     except NoCredentialsError:
-        print(f"  ❌ AWS credentials not found")
-        print(f"     Please configure AWS credentials:")
-        print(f"     - Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables")
-        print(f"     - Or run 'aws configure'")
+        print("  ❌ AWS credentials not found")
+        print("     Please configure AWS credentials:")
+        print("     - Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables")
+        print("     - Or run 'aws configure'")
         return False
     except Exception as e:
         print(f"  ❌ AWS connectivity failed: {e}")
@@ -97,11 +98,10 @@ def check_aws_connectivity(region: str) -> bool:
 
 def check_redshift_serverless_availability(region: str, namespace: str, workgroup: str) -> Optional[Dict]:
     """Check if Redshift Serverless resources exist and are available."""
-    print(f"\n🔍 Checking Redshift Serverless resources...")
+    print("\n🔍 Checking Redshift Serverless resources...")
 
     # Import and use the management script
     import subprocess
-    import json
 
     try:
         # Use the management script to check status
@@ -110,7 +110,7 @@ def check_redshift_serverless_availability(region: str, namespace: str, workgrou
         ], capture_output=True, text=True)
 
         if result.returncode == 0:
-            print(f"  ✅ Redshift cluster status checked using management script")
+            print("  ✅ Redshift cluster status checked using management script")
             # Try to get endpoint if resources exist
             endpoint_result = subprocess.run([
                 "python", "scripts/manage-redshift-cluster.py", "--region", region, "endpoint",
@@ -137,7 +137,7 @@ def check_redshift_serverless_availability(region: str, namespace: str, workgrou
                 except FileNotFoundError:
                     pass
         else:
-            print(f"  ⚠️  Redshift resources not available - will be created during testing")
+            print("  ⚠️  Redshift resources not available - will be created during testing")
 
         return None
 
@@ -148,7 +148,7 @@ def check_redshift_serverless_availability(region: str, namespace: str, workgrou
 
 def test_redshift_connection(connection_info: Dict) -> bool:
     """Test direct connection to Redshift if endpoint is available."""
-    print(f"\n🔍 Testing direct Redshift connection...")
+    print("\n🔍 Testing direct Redshift connection...")
 
     try:
         # Get credentials from environment variables
@@ -156,8 +156,8 @@ def test_redshift_connection(connection_info: Dict) -> bool:
         admin_password = os.getenv("REDSHIFT_ADMIN_PASSWORD")
 
         if not admin_password:
-            print(f"  ⚠️  REDSHIFT_ADMIN_PASSWORD not set, skipping connection test")
-            print(f"     Set this environment variable to test direct connections")
+            print("  ⚠️  REDSHIFT_ADMIN_PASSWORD not set, skipping connection test")
+            print("     Set this environment variable to test direct connections")
             return False
 
         connection_string = (
@@ -174,7 +174,7 @@ def test_redshift_connection(connection_info: Dict) -> bool:
         # Test basic query
         cursor.execute("SELECT version()")
         version = cursor.fetchone()[0]
-        print(f"  ✅ Connection successful")
+        print("  ✅ Connection successful")
         print(f"  ✅ Redshift version: {version[:50]}...")
 
         # Test create/drop table permissions
@@ -186,7 +186,7 @@ def test_redshift_connection(connection_info: Dict) -> bool:
         """)
         cursor.execute("DROP TABLE IF EXISTS test_table")
         conn.commit()
-        print(f"  ✅ Create/drop table permissions: OK")
+        print("  ✅ Create/drop table permissions: OK")
 
         cursor.close()
         conn.close()
@@ -194,14 +194,14 @@ def test_redshift_connection(connection_info: Dict) -> bool:
 
     except Exception as e:
         print(f"  ❌ Connection failed: {e}")
-        print(f"     This might be normal if Redshift is not running")
+        print("     This might be normal if Redshift is not running")
         return False
 
 
 def check_required_permissions() -> None:
     """Display required IAM permissions for Redshift integration testing."""
-    print(f"\n📋 Required IAM Permissions for Redshift Integration Testing:")
-    print(f"""
+    print("\n📋 Required IAM Permissions for Redshift Integration Testing:")
+    print("""
     The AWS user/role needs the following permissions:
 
     Redshift Serverless permissions:
@@ -223,10 +223,10 @@ def check_required_permissions() -> None:
     - ec2:AuthorizeSecurityGroupIngress (for automatic security group configuration)
 
     Example IAM policy:
-    {{
+    {
         "Version": "2012-10-17",
         "Statement": [
-            {{
+            {
                 "Effect": "Allow",
                 "Action": [
                     "redshift-serverless:*",
@@ -240,9 +240,9 @@ def check_required_permissions() -> None:
                     "ec2:AuthorizeSecurityGroupIngress"
                 ],
                 "Resource": "*"
-            }}
+            }
         ]
-    }}
+    }
 
     Note: Redshift Serverless resources incur costs. The free trial provides
     $300 in credits for new users. Monitor your usage in the AWS console.
@@ -263,13 +263,13 @@ def main():
     region = env_vars["AWS_REGION"]
 
     if not env_vars["AWS_ACCESS_KEY_ID"] or not env_vars["AWS_SECRET_ACCESS_KEY"]:
-        print(f"\n❌ Missing required AWS credentials")
+        print("\n❌ Missing required AWS credentials")
         check_required_permissions()
         sys.exit(1)
 
     # Check AWS connectivity
     if not check_aws_connectivity(region):
-        print(f"\n❌ AWS connectivity check failed")
+        print("\n❌ AWS connectivity check failed")
         check_required_permissions()
         sys.exit(1)
 
@@ -282,30 +282,30 @@ def main():
         connection_success = test_redshift_connection(connection_info)
 
     # Summary
-    print(f"\n📊 Validation Summary:")
-    print(f"=" * 30)
-    print(f"✅ Environment variables: OK")
-    print(f"✅ AWS connectivity: OK")
+    print("\n📊 Validation Summary:")
+    print("=" * 30)
+    print("✅ Environment variables: OK")
+    print("✅ AWS connectivity: OK")
     print(f"ℹ️  Redshift resources: {'Available' if connection_info else 'Will be created during testing'}")
     print(f"{'✅' if connection_success else 'ℹ️ '} Direct connection: {'OK' if connection_success else 'Not tested (resources not available)'}")
 
-    print(f"\n🎯 Next Steps:")
+    print("\n🎯 Next Steps:")
     if connection_info and connection_success:
-        print(f"  • Your environment is fully configured for Redshift testing")
-        print(f"  • You can run integration tests immediately")
+        print("  • Your environment is fully configured for Redshift testing")
+        print("  • You can run integration tests immediately")
     else:
-        print(f"  • Use the management script to create/manage Redshift resources:")
-        print(f"    python scripts/manage-redshift-cluster.py create")
-        print(f"  • Run integration tests manually:")
-        print(f"    poetry run pytest tests/integration/test_redshift_integration.py -v")
-        print(f"  • Clean up resources when done:")
-        print(f"    python scripts/manage-redshift-cluster.py destroy")
+        print("  • Use the management script to create/manage Redshift resources:")
+        print("    python scripts/manage-redshift-cluster.py create")
+        print("  • Run integration tests manually:")
+        print("    poetry run pytest tests/integration/test_redshift_integration.py -v")
+        print("  • Clean up resources when done:")
+        print("    python scripts/manage-redshift-cluster.py destroy")
 
-    print(f"\n💰 Cost Information:")
-    print(f"  • Redshift Serverless costs ~$3/hour minimum when active")
-    print(f"  • Free trial provides $300 credit for new users")
-    print(f"  • Resources are automatically cleaned up after tests")
-    print(f"  • Monitor usage in AWS console to avoid unexpected charges")
+    print("\n💰 Cost Information:")
+    print("  • Redshift Serverless costs ~$3/hour minimum when active")
+    print("  • Free trial provides $300 credit for new users")
+    print("  • Resources are automatically cleaned up after tests")
+    print("  • Monitor usage in AWS console to avoid unexpected charges")
 
     check_required_permissions()
 

--- a/scripts/validate-snowflake-setup.py
+++ b/scripts/validate-snowflake-setup.py
@@ -8,7 +8,7 @@ and tests basic connectivity to Snowflake.
 
 import os
 import sys
-from typing import List, Optional
+from typing import List
 
 
 def check_environment_variables() -> List[str]:

--- a/src/sql_testing_library/_sql_utils.py
+++ b/src/sql_testing_library/_sql_utils.py
@@ -202,8 +202,13 @@ def format_sql_value(value: Any, column_type: Type, dialect: str = "standard") -
             element_type = get_args(column_type)[0] if get_args(column_type) else str
 
             if dialect in ("athena", "trino"):
+                # Check if element type is a struct
+                if is_struct_type(element_type):
+                    # Get the SQL type for the struct
+                    sql_element_type = get_sql_type_string(element_type, dialect)
+                    return f"CAST(NULL AS ARRAY({sql_element_type}))"
                 # Map Python types to SQL types for array elements
-                if element_type == Decimal:
+                elif element_type == Decimal:
                     sql_element_type = "DECIMAL(38,9)"
                 elif element_type is int:
                     sql_element_type = "INTEGER" if dialect == "athena" else "BIGINT"

--- a/src/sql_testing_library/_types.py
+++ b/src/sql_testing_library/_types.py
@@ -149,8 +149,9 @@ def _parse_key_value_pairs(
             # Convert key to proper type
             converted_key = converter.convert(key_str, key_type)
 
-            # Get value type - if value_type is callable, call it with the key
-            if callable(value_type):
+            # Get value type - if value_type is a custom callable (not a type), call it with the key
+            # Built-in types like int, str, float are callable but shouldn't be called here
+            if callable(value_type) and not isinstance(value_type, type):
                 actual_value_type = value_type(key_str)
             else:
                 actual_value_type = value_type

--- a/src/sql_testing_library/_types.py
+++ b/src/sql_testing_library/_types.py
@@ -250,9 +250,14 @@ class BaseTypeConverter:
 
             # If value is a string representation of an array, parse it
             if isinstance(value, str):
-                # Parse string array format like '[hello, world, athena]' or '[1, 2, 3]'
-                elements = _parse_bracketed_string(value, "[", "]")
-                if not elements:
+                # Check if it's an array format
+                if value.startswith("[") and value.endswith("]"):
+                    # Parse string array format like '[hello, world, athena]' or '[1, 2, 3]'
+                    elements = _parse_bracketed_string(value, "[", "]")
+                    # Return empty list for empty arrays
+                    if not elements:
+                        return []
+                else:
                     # If it doesn't look like array format, try to convert as single element list
                     element_type = get_args(target_type)[0] if get_args(target_type) else str
                     converted_element = self.convert(value, element_type)

--- a/src/sql_testing_library/_types.py
+++ b/src/sql_testing_library/_types.py
@@ -1,11 +1,165 @@
 """Type conversion utilities."""
 
+from dataclasses import is_dataclass
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Type, TypeVar, Union, cast, get_args, get_origin
+from typing import Any, Dict, List, Type, TypeVar, Union, cast, get_args, get_origin, get_type_hints
 
 
 T = TypeVar("T")
+
+
+try:
+    from pydantic import BaseModel
+
+    pydantic_available = True
+except ImportError:
+    BaseModel = None  # type: ignore
+    pydantic_available = False
+
+
+def is_pydantic_model_class(cls: Type) -> bool:
+    """Check if a class is a Pydantic model class."""
+    if not pydantic_available or BaseModel is None:
+        return False
+    try:
+        return issubclass(cls, BaseModel)
+    except TypeError:
+        # Handle cases where cls is not a class
+        return False
+
+
+def is_struct_type(type_hint: Type) -> bool:
+    """Check if a type is a struct type (dataclass or Pydantic model)."""
+    # Handle Optional types
+    if hasattr(type_hint, "__origin__") and type_hint.__origin__ is Union:
+        # Extract the non-None type from Optional[T]
+        non_none_types = [arg for arg in get_args(type_hint) if arg is not type(None)]
+        if non_none_types:
+            type_hint = non_none_types[0]
+
+    return is_dataclass(type_hint) or is_pydantic_model_class(type_hint)
+
+
+def _get_struct_field_names(struct_type: Type) -> List[str]:
+    """Get ordered field names for a struct type (dataclass or Pydantic model)."""
+    if is_dataclass(struct_type):
+        # For dataclasses, use __dataclass_fields__ to preserve order
+        return list(struct_type.__dataclass_fields__.keys())
+    elif is_pydantic_model_class(struct_type) and pydantic_available:
+        # For Pydantic models, use model_fields
+        return list(struct_type.model_fields.keys())
+    else:
+        # Fallback to type hints order (Python 3.7+ preserves dict order)
+        return list(get_type_hints(struct_type).keys())
+
+
+def _create_struct_instance(struct_type: Type, field_values: Dict[str, Any]) -> Any:
+    """Create a struct instance from field values."""
+    if is_dataclass(struct_type):
+        return struct_type(**field_values)
+    elif is_pydantic_model_class(struct_type) and pydantic_available:
+        return struct_type(**field_values)
+    else:
+        # Fallback: try to construct with values or empty
+        try:
+            return struct_type(**field_values)
+        except Exception:
+            return struct_type()
+
+
+def _parse_bracketed_string(
+    value: str, open_bracket: str = "{", close_bracket: str = "}"
+) -> List[str]:
+    """Parse a bracket-delimited string considering nested brackets."""
+    if not value.startswith(open_bracket) or not value.endswith(close_bracket):
+        return []
+
+    inner_value = value[1:-1].strip()
+    if not inner_value:
+        return []
+
+    parts = []
+    current_part = ""
+    bracket_count = 0
+
+    for char in inner_value:
+        if char in "{[":
+            bracket_count += 1
+        elif char in "}]":
+            bracket_count -= 1
+        elif char == "," and bracket_count == 0:
+            parts.append(current_part.strip())
+            current_part = ""
+            continue
+        current_part += char
+
+    if current_part.strip():
+        parts.append(current_part.strip())
+
+    return parts
+
+
+def _parse_string_value(value_str: str) -> Any:
+    """Parse a string value to appropriate Python type."""
+    value_lower = value_str.lower()
+
+    # Check for boolean values
+    if value_lower == "true":
+        return True
+    elif value_lower == "false":
+        return False
+    elif value_lower == "null":
+        return None
+
+    # Try to parse as number
+    try:
+        if "." in value_str:
+            return float(value_str)
+        else:
+            return int(value_str)
+    except ValueError:
+        # Not a number, return as string
+        return value_str
+
+
+def _parse_key_value_pairs(
+    pairs: List[str], converter, key_type: Type = str, value_type: Type = str
+) -> Dict[str, Any]:
+    """Parse key=value pairs and convert them to proper types.
+
+    Args:
+        pairs: List of "key=value" strings
+        converter: Type converter instance with convert method
+        key_type: Expected type for keys
+        value_type: Expected type for values (or callable that returns type based on key)
+
+    Returns:
+        Dictionary with converted keys and values
+    """
+    result = {}
+    for pair in pairs:
+        # Split by first = to handle values that contain =
+        parts = pair.split("=", 1)
+        if len(parts) == 2:
+            key_str, value_str = parts
+            key_str = key_str.strip()
+            value_str = value_str.strip()
+
+            # Convert key to proper type
+            converted_key = converter.convert(key_str, key_type)
+
+            # Get value type - if value_type is callable, call it with the key
+            if callable(value_type):
+                actual_value_type = value_type(key_str)
+            else:
+                actual_value_type = value_type
+
+            # Convert value to proper type
+            converted_value = converter.convert(value_str, actual_value_type)
+            result[converted_key] = converted_value
+
+    return result
 
 
 class BaseTypeConverter:
@@ -39,6 +193,10 @@ class BaseTypeConverter:
                 return None
             target_type = self.get_optional_inner_type(target_type)
 
+        # Handle struct types (dataclass or Pydantic model)
+        if is_struct_type(target_type):
+            return self._convert_struct(value, target_type)
+
         # Handle dict/map types
         if hasattr(target_type, "__origin__") and target_type.__origin__ is dict:
             # If value is already a dict, return it
@@ -48,54 +206,16 @@ class BaseTypeConverter:
             # If value is a string representation of a map, parse it
             if isinstance(value, str):
                 # Parse string map format like '{key1=value1, key2=value2}' (Athena/Trino format)
-                if value.startswith("{") and value.endswith("}"):
-                    inner_value = value[1:-1].strip()
-                    if not inner_value:  # Empty map
-                        return {}
-
-                    # Get the key and value types from Dict[K, V]
-                    type_args = get_args(target_type)
-                    key_type = type_args[0] if type_args else str
-                    value_type = type_args[1] if len(type_args) > 1 else str
-
-                    # Split by comma and parse key=value pairs
-                    result = {}
-                    # Handle nested structures by tracking brackets
-                    pairs = []
-                    current_pair = ""
-                    bracket_count = 0
-
-                    for char in inner_value:
-                        if char in "{[":
-                            bracket_count += 1
-                        elif char in "}]":
-                            bracket_count -= 1
-                        elif char == "," and bracket_count == 0:
-                            pairs.append(current_pair.strip())
-                            current_pair = ""
-                            continue
-                        current_pair += char
-
-                    if current_pair.strip():
-                        pairs.append(current_pair.strip())
-
-                    for pair in pairs:
-                        # Split by first = to handle values that contain =
-                        parts = pair.split("=", 1)
-                        if len(parts) == 2:
-                            key_str, value_str = parts
-                            key_str = key_str.strip()
-                            value_str = value_str.strip()
-
-                            # Convert key and value to proper types
-                            converted_key = self.convert(key_str, key_type)
-                            converted_value = self.convert(value_str, value_type)
-                            result[converted_key] = converted_value
-
-                    return result
-                else:
-                    # If it doesn't look like map format, return empty dict
+                pairs = _parse_bracketed_string(value)
+                if not pairs:
                     return {}
+
+                # Get the key and value types from Dict[K, V]
+                type_args = get_args(target_type)
+                key_type = type_args[0] if type_args else str
+                value_type = type_args[1] if len(type_args) > 1 else str
+
+                return _parse_key_value_pairs(pairs, self, key_type, value_type)
 
             # For other types, try to convert to dict
             return {} if value is None else {}
@@ -124,35 +244,28 @@ class BaseTypeConverter:
             # If value is a string representation of an array, parse it
             if isinstance(value, str):
                 # Parse string array format like '[hello, world, athena]' or '[1, 2, 3]'
-                # Remove outer brackets and split by comma
-                if value.startswith("[") and value.endswith("]"):
-                    inner_value = value[1:-1].strip()
-                    if not inner_value:  # Empty array
-                        return []
-
-                    # Split by comma and clean up each element
-                    elements = [elem.strip() for elem in inner_value.split(",")]
-
-                    # Get the element type from List[T]
-                    element_type = get_args(target_type)[0] if get_args(target_type) else str
-
-                    # Convert each element to the proper type
-                    converted_elements = []
-                    for element in elements:
-                        # Remove quotes if present (for string elements)
-                        if element.startswith(("'", '"')) and element.endswith(("'", '"')):
-                            element = element[1:-1]
-
-                        # Recursively convert each element
-                        converted_element = self.convert(element, element_type)
-                        converted_elements.append(converted_element)
-
-                    return converted_elements
-                else:
+                elements = _parse_bracketed_string(value, "[", "]")
+                if not elements:
                     # If it doesn't look like array format, try to convert as single element list
                     element_type = get_args(target_type)[0] if get_args(target_type) else str
                     converted_element = self.convert(value, element_type)
                     return [converted_element]
+
+                # Get the element type from List[T]
+                element_type = get_args(target_type)[0] if get_args(target_type) else str
+
+                # Convert each element to the proper type
+                converted_elements = []
+                for element in elements:
+                    # Remove quotes if present (for string elements)
+                    if element.startswith(("'", '"')) and element.endswith(("'", '"')):
+                        element = element[1:-1]
+
+                    # Recursively convert each element
+                    converted_element = self.convert(element, element_type)
+                    converted_elements.append(converted_element)
+
+                return converted_elements
 
             # For other types, try to convert to list
             return [value] if value is not None else []
@@ -185,6 +298,85 @@ class BaseTypeConverter:
         else:
             # For unsupported types, convert to string
             return str(value)
+
+    def _convert_struct(self, value: Any, target_type: Type) -> Any:
+        """Convert value to struct type (dataclass or Pydantic model)."""
+        # If value is already an instance of the target type, return it
+        if isinstance(value, target_type):
+            return value
+
+        # Get type hints for the struct
+        type_hints = get_type_hints(target_type)
+
+        # If value is a dict, construct the struct from it
+        if isinstance(value, dict):
+            return _create_struct_instance(target_type, value)
+
+        # If value is a tuple (Athena/Trino returns structs as tuples)
+        if isinstance(value, tuple):
+            field_names = _get_struct_field_names(target_type)
+
+            # Convert tuple values to dict mapping field names to values
+            result = {}
+            for i, (field_name, field_value) in enumerate(zip(field_names, value)):
+                if i < len(value):  # Ensure we don't go out of bounds
+                    field_type = type_hints.get(field_name, str)
+                    # Recursively convert the field value
+                    converted_value = self.convert(field_value, field_type)
+                    result[field_name] = converted_value
+
+            return _create_struct_instance(target_type, result)
+
+        # If value is a string representation of a struct (from SQL query result)
+        if isinstance(value, str):
+            # Parse Athena/Trino struct format
+            if value.startswith("{") and value.endswith("}"):
+                inner_value = value[1:-1].strip()
+                if not inner_value:  # Empty struct
+                    return _create_struct_instance(target_type, {})
+
+                # Check if it's a simple comma-separated format (like Athena returns)
+                # e.g., "{John Doe, 30, 75000.5, {123 Main St, New York, 10001}, true}"
+                if "=" not in inner_value or inner_value.count(",") > inner_value.count("="):
+                    # This looks like positional values, not key=value pairs
+                    field_names = _get_struct_field_names(target_type)
+                    values = _parse_bracketed_string(value)
+
+                    # Convert values to dict
+                    result = {}
+                    for field_name, value_str in zip(field_names, values):
+                        field_type = type_hints.get(field_name, str)
+                        # Handle nested structs
+                        if value_str.startswith("{") and value_str.endswith("}"):
+                            converted_value = self.convert(value_str, field_type)
+                        else:
+                            # Parse the string value to appropriate type
+                            parsed_value = _parse_string_value(value_str)
+                            converted_value = self.convert(parsed_value, field_type)
+                        result[field_name] = converted_value
+
+                    return _create_struct_instance(target_type, result)
+
+                # Parse key=value pairs
+                pairs = _parse_bracketed_string(value)
+
+                # Parse pairs and get field values
+                result = {}
+                for pair in pairs:
+                    if "=" in pair:
+                        key, value_str = pair.split("=", 1)
+                        key = key.strip()
+                        value_str = value_str.strip()
+                        # Get the field type for this key
+                        field_type = type_hints.get(key, str)
+                        # Parse and convert the value
+                        parsed_value = _parse_string_value(value_str)
+                        result[key] = self.convert(parsed_value, field_type)
+
+                return _create_struct_instance(target_type, result)
+
+        # Fallback: try to construct with empty values
+        return _create_struct_instance(target_type, {})
 
 
 def unwrap_optional_type(col_type: Type[Any]) -> Type[Any]:

--- a/tests/integration/test_struct_types_integration.py
+++ b/tests/integration/test_struct_types_integration.py
@@ -1,0 +1,344 @@
+"""Integration tests for struct types across database adapters."""
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel
+
+from sql_testing_library import TestCase, sql_test
+from sql_testing_library._mock_table import BaseMockTable
+
+
+@dataclass
+class Address:
+    """Nested struct for testing."""
+
+    street: str
+    city: str
+    zip_code: str
+
+
+@dataclass
+class Person:
+    """Main struct for testing."""
+
+    name: str
+    age: int
+    salary: Decimal
+    address: Address
+    is_active: bool = True
+
+
+class AddressPydantic(BaseModel):
+    """Pydantic version of Address struct."""
+
+    street: str
+    city: str
+    zip_code: str
+
+
+class PersonPydantic(BaseModel):
+    """Pydantic version of Person struct."""
+
+    name: str
+    age: int
+    salary: Decimal
+    address: AddressPydantic
+    is_active: bool = True
+
+
+@dataclass
+class StructTypesData:
+    """Test data class with struct fields."""
+
+    id: int
+    person: Person
+    optional_person: Optional[Person] = None
+
+
+class StructTypesResult(BaseModel):
+    """Result model for struct types test."""
+
+    id: int
+    person: PersonPydantic
+    optional_person: Optional[PersonPydantic]
+
+
+class StructTypesMockTable(BaseMockTable):
+    """Mock table for struct types testing."""
+
+    def __init__(self, data, database_name: str):
+        super().__init__(data)
+        self._database_name = database_name
+
+    def get_database_name(self) -> str:
+        return self._database_name
+
+    def get_table_name(self) -> str:
+        return "struct_types"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("adapter_type", ["athena", "trino"])
+@pytest.mark.parametrize(
+    "use_physical_tables", [False, True], ids=["cte_mode", "physical_tables_mode"]
+)
+class TestStructTypesIntegration:
+    """Integration tests for struct types in Athena and Trino."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test_data(self, adapter_type):
+        """Set up test data specific to each adapter."""
+        # Common test data structure for all adapters
+        self.test_data = [
+            StructTypesData(
+                id=1,
+                person=Person(
+                    name="John Doe",
+                    age=30,
+                    salary=Decimal("75000.50"),
+                    address=Address(street="123 Main St", city="New York", zip_code="10001"),
+                    is_active=True,
+                ),
+                optional_person=Person(
+                    name="Jane Smith",
+                    age=25,
+                    salary=Decimal("65000.00"),
+                    address=Address(street="456 Oak Ave", city="Boston", zip_code="02101"),
+                    is_active=False,
+                ),
+            ),
+            StructTypesData(
+                id=2,
+                person=Person(
+                    name="Bob Johnson",
+                    age=45,
+                    salary=Decimal("95000.75"),
+                    address=Address(street="789 Pine Rd", city="Chicago", zip_code="60601"),
+                    is_active=True,
+                ),
+                optional_person=None,
+            ),
+            StructTypesData(
+                id=3,
+                person=Person(
+                    name="Alice Brown",
+                    age=35,
+                    salary=Decimal("85000.25"),
+                    address=Address(street="321 Elm Way", city="Seattle", zip_code="98101"),
+                    is_active=True,
+                ),
+                optional_person=Person(
+                    name="Charlie Davis",
+                    age=40,
+                    salary=Decimal("90000.00"),
+                    address=Address(street="654 Maple Dr", city="Portland", zip_code="97201"),
+                    is_active=True,
+                ),
+            ),
+        ]
+
+        # Set database name based on adapter type
+        if adapter_type == "athena":
+            self.database_name = "test_db"
+        elif adapter_type == "trino":
+            self.database_name = "memory"
+
+    def test_struct_types_basic_query(self, adapter_type, use_physical_tables):
+        """Test basic struct type queries."""
+
+        @sql_test(
+            adapter_type=adapter_type,
+            mock_tables=[StructTypesMockTable(self.test_data, self.database_name)],
+            result_class=StructTypesResult,
+        )
+        def query_struct_types():
+            return TestCase(
+                query="""
+                    SELECT
+                        id,
+                        person,
+                        optional_person
+                    FROM struct_types
+                    ORDER BY id
+                """,
+                default_namespace=self.database_name,
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_struct_types()
+        assert len(results) == 3
+
+        # Verify first row
+        row1 = results[0]
+        assert row1.id == 1
+        assert row1.person.name == "John Doe"
+        assert row1.person.age == 30
+        assert row1.person.salary == Decimal("75000.50")
+        assert row1.person.address.street == "123 Main St"
+        assert row1.person.address.city == "New York"
+        assert row1.person.address.zip_code == "10001"
+        assert row1.person.is_active is True
+        assert row1.optional_person is not None
+        assert row1.optional_person.name == "Jane Smith"
+
+        # Verify second row (with NULL optional_person)
+        row2 = results[1]
+        assert row2.id == 2
+        assert row2.person.name == "Bob Johnson"
+        assert row2.optional_person is None
+
+        # Verify third row
+        row3 = results[2]
+        assert row3.id == 3
+        assert row3.person.name == "Alice Brown"
+        assert row3.optional_person is not None
+        assert row3.optional_person.name == "Charlie Davis"
+
+    def test_struct_field_access_with_dot_notation(self, adapter_type, use_physical_tables):
+        """Test accessing struct fields using dot notation."""
+
+        @dataclass
+        class DotNotationResult:
+            id: int
+            person_name: str
+            person_age: int
+            person_salary: Decimal
+            address_city: str
+            address_zip: str
+            is_active: bool
+
+        @sql_test(
+            adapter_type=adapter_type,
+            mock_tables=[StructTypesMockTable(self.test_data, self.database_name)],
+            result_class=DotNotationResult,
+        )
+        def query_struct_fields():
+            return TestCase(
+                query="""
+                    SELECT
+                        id,
+                        person.name AS person_name,
+                        person.age AS person_age,
+                        person.salary AS person_salary,
+                        person.address.city AS address_city,
+                        person.address.zip_code AS address_zip,
+                        person.is_active AS is_active
+                    FROM struct_types
+                    ORDER BY id
+                """,
+                default_namespace=self.database_name,
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_struct_fields()
+        assert len(results) == 3
+
+        # Verify first row
+        row1 = results[0]
+        assert row1.id == 1
+        assert row1.person_name == "John Doe"
+        assert row1.person_age == 30
+        assert row1.person_salary == Decimal("75000.50")
+        assert row1.address_city == "New York"
+        assert row1.address_zip == "10001"
+        assert row1.is_active is True
+
+        # Verify other rows
+        row2 = results[1]
+        assert row2.person_name == "Bob Johnson"
+        assert row2.address_city == "Chicago"
+
+        row3 = results[2]
+        assert row3.person_name == "Alice Brown"
+        assert row3.address_city == "Seattle"
+
+    def test_struct_in_where_clause(self, adapter_type, use_physical_tables):
+        """Test using struct fields in WHERE clause."""
+
+        @dataclass
+        class WhereClauseResult:
+            id: int
+            person_name: str
+            city: str
+
+        @sql_test(
+            adapter_type=adapter_type,
+            mock_tables=[StructTypesMockTable(self.test_data, self.database_name)],
+            result_class=WhereClauseResult,
+        )
+        def query_with_where():
+            return TestCase(
+                query="""
+                    SELECT
+                        id,
+                        person.name AS person_name,
+                        person.address.city AS city
+                    FROM struct_types
+                    WHERE person.age > 30
+                        AND person.is_active = TRUE
+                    ORDER BY id
+                """,
+                default_namespace=self.database_name,
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_with_where()
+        assert len(results) == 2
+
+        # Should return Bob Johnson and Alice Brown
+        assert results[0].person_name == "Bob Johnson"
+        assert results[1].person_name == "Alice Brown"
+
+    def test_struct_with_null_handling(self, adapter_type, use_physical_tables):
+        """Test NULL handling in optional struct fields."""
+
+        @dataclass
+        class NullHandlingResult:
+            id: int
+            has_optional_person: bool
+            optional_person_name: Optional[str]
+
+        @sql_test(
+            adapter_type=adapter_type,
+            mock_tables=[StructTypesMockTable(self.test_data, self.database_name)],
+            result_class=NullHandlingResult,
+        )
+        def query_null_handling():
+            return TestCase(
+                query="""
+                    SELECT
+                        id,
+                        optional_person IS NOT NULL AS has_optional_person,
+                        CASE
+                            WHEN optional_person IS NOT NULL
+                            THEN optional_person.name
+                            ELSE NULL
+                        END AS optional_person_name
+                    FROM struct_types
+                    ORDER BY id
+                """,
+                default_namespace=self.database_name,
+                use_physical_tables=use_physical_tables,
+            )
+
+        results = query_null_handling()
+        assert len(results) == 3
+
+        # First row has optional_person
+        assert results[0].has_optional_person is True
+        assert results[0].optional_person_name == "Jane Smith"
+
+        # Second row has NULL optional_person
+        assert results[1].has_optional_person is False
+        assert results[1].optional_person_name is None
+
+        # Third row has optional_person
+        assert results[2].has_optional_person is True
+        assert results[2].optional_person_name == "Charlie Davis"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_struct_types.py
+++ b/tests/test_struct_types.py
@@ -38,24 +38,24 @@ class PydanticPerson(BaseModel):
 class TestStructTypeDetection:
     """Test struct type detection functions."""
 
-    def testis_struct_type_with_dataclass(self):
+    def test_is_struct_type_with_dataclass(self):
         """Test that dataclasses are detected as struct types."""
         assert is_struct_type(Person) is True
         assert is_struct_type(Address) is True
 
-    def testis_struct_type_with_pydantic(self):
+    def test_is_struct_type_with_pydantic(self):
         """Test that Pydantic models are detected as struct types."""
         assert is_struct_type(PydanticPerson) is True
         assert is_struct_type(PydanticAddress) is True
 
-    def testis_struct_type_with_regular_types(self):
+    def test_is_struct_type_with_regular_types(self):
         """Test that regular types are not detected as struct types."""
         assert is_struct_type(str) is False
         assert is_struct_type(int) is False
         assert is_struct_type(list) is False
         assert is_struct_type(dict) is False
 
-    def testis_pydantic_model_class(self):
+    def test_is_pydantic_model_class(self):
         """Test Pydantic model class detection."""
         assert is_pydantic_model_class(PydanticPerson) is True
         assert is_pydantic_model_class(PydanticAddress) is True
@@ -207,6 +207,134 @@ class TestStructTupleConversion:
         assert result.address.street == "789 Pine Rd"
         assert result.address.city == "Chicago"
         assert result.address.zip_code == "60601"
+
+
+class TestListOfStructs:
+    """Test list of structs support."""
+
+    def test_format_list_of_dataclass_structs_athena(self):
+        """Test formatting list of dataclass structs for Athena."""
+        from typing import List
+
+        addresses = [
+            Address(street="123 Main St", city="New York", zip_code="10001"),
+            Address(street="456 Oak Ave", city="Boston", zip_code="02101"),
+            Address(street="789 Pine Rd", city="Chicago", zip_code="60601"),
+        ]
+
+        result = format_sql_value(addresses, List[Address], dialect="athena")
+        # Should format as ARRAY[CAST(ROW(...) AS ROW(...)), ...]
+        assert result.startswith("ARRAY[")
+        assert result.endswith("]")
+        assert result.count("CAST(ROW(") == 3  # Three structs
+        assert "'123 Main St'" in result
+        assert "'New York'" in result
+        assert "'456 Oak Ave'" in result
+        assert "'Boston'" in result
+        assert "'789 Pine Rd'" in result
+        assert "'Chicago'" in result
+
+    def test_format_list_of_pydantic_structs_trino(self):
+        """Test formatting list of Pydantic structs for Trino."""
+        from typing import List
+
+        addresses = [
+            PydanticAddress(street="123 Main St", city="New York", zip_code="10001"),
+            PydanticAddress(street="456 Oak Ave", city="Boston", zip_code="02101"),
+        ]
+
+        result = format_sql_value(addresses, List[PydanticAddress], dialect="trino")
+        # Should format as ARRAY[CAST(ROW(...) AS ROW(...)), ...]
+        assert result.startswith("ARRAY[")
+        assert result.endswith("]")
+        assert result.count("CAST(ROW(") == 2  # Two structs
+        assert "street VARCHAR" in result
+        assert "city VARCHAR" in result
+        assert "zip_code VARCHAR" in result
+
+    def test_format_empty_list_of_structs_athena(self):
+        """Test formatting empty list of structs for Athena."""
+        from typing import List
+
+        result = format_sql_value([], List[Address], dialect="athena")
+        # Should format as ARRAY[]
+        assert result == "ARRAY[]"
+
+    def test_format_null_list_of_structs_athena(self):
+        """Test formatting NULL list of structs for Athena."""
+        from typing import List
+
+        result = format_sql_value(None, List[Address], dialect="athena")
+        # Should format as CAST(NULL AS ARRAY(ROW(...)))
+        assert result.startswith("CAST(NULL AS ARRAY(")
+        assert "ROW(" in result
+        assert "street VARCHAR" in result
+        assert "city VARCHAR" in result
+        assert "zip_code VARCHAR" in result
+
+    def test_convert_list_of_tuples_to_dataclass_structs(self):
+        """Test converting list of tuples to list of dataclass structs."""
+        from typing import List
+
+        converter = BaseTypeConverter()
+
+        # List of tuples representing addresses
+        address_tuples = [
+            ("123 Main St", "New York", "10001"),
+            ("456 Oak Ave", "Boston", "02101"),
+            ("789 Pine Rd", "Chicago", "60601"),
+        ]
+
+        result = converter.convert(address_tuples, List[Address])
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+
+        # Check first address
+        assert isinstance(result[0], Address)
+        assert result[0].street == "123 Main St"
+        assert result[0].city == "New York"
+        assert result[0].zip_code == "10001"
+
+        # Check second address
+        assert isinstance(result[1], Address)
+        assert result[1].street == "456 Oak Ave"
+        assert result[1].city == "Boston"
+        assert result[1].zip_code == "02101"
+
+        # Check third address
+        assert isinstance(result[2], Address)
+        assert result[2].street == "789 Pine Rd"
+        assert result[2].city == "Chicago"
+        assert result[2].zip_code == "60601"
+
+    def test_convert_list_of_string_structs_to_dataclass(self):
+        """Test converting list of string representations to list of dataclass structs."""
+        from typing import List
+
+        converter = BaseTypeConverter()
+
+        # List of string representations (as might come from Athena)
+        address_strings = [
+            "{123 Main St, New York, 10001}",
+            "{456 Oak Ave, Boston, 02101}",
+        ]
+
+        result = converter.convert(address_strings, List[Address])
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        # Check addresses
+        assert isinstance(result[0], Address)
+        assert result[0].street == "123 Main St"
+        assert result[0].city == "New York"
+        assert result[0].zip_code == "10001"
+
+        assert isinstance(result[1], Address)
+        assert result[1].street == "456 Oak Ave"
+        assert result[1].city == "Boston"
+        assert result[1].zip_code == "02101"
 
 
 if __name__ == "__main__":

--- a/tests/test_struct_types.py
+++ b/tests/test_struct_types.py
@@ -1,0 +1,213 @@
+"""Unit tests for struct type support."""
+
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel
+
+from sql_testing_library._sql_utils import format_sql_value
+from sql_testing_library._types import BaseTypeConverter, is_pydantic_model_class, is_struct_type
+
+
+@dataclass
+class Address:
+    street: str
+    city: str
+    zip_code: str
+
+
+@dataclass
+class Person:
+    name: str
+    age: int
+    address: Address
+
+
+class PydanticAddress(BaseModel):
+    street: str
+    city: str
+    zip_code: str
+
+
+class PydanticPerson(BaseModel):
+    name: str
+    age: int
+    address: PydanticAddress
+
+
+class TestStructTypeDetection:
+    """Test struct type detection functions."""
+
+    def testis_struct_type_with_dataclass(self):
+        """Test that dataclasses are detected as struct types."""
+        assert is_struct_type(Person) is True
+        assert is_struct_type(Address) is True
+
+    def testis_struct_type_with_pydantic(self):
+        """Test that Pydantic models are detected as struct types."""
+        assert is_struct_type(PydanticPerson) is True
+        assert is_struct_type(PydanticAddress) is True
+
+    def testis_struct_type_with_regular_types(self):
+        """Test that regular types are not detected as struct types."""
+        assert is_struct_type(str) is False
+        assert is_struct_type(int) is False
+        assert is_struct_type(list) is False
+        assert is_struct_type(dict) is False
+
+    def testis_pydantic_model_class(self):
+        """Test Pydantic model class detection."""
+        assert is_pydantic_model_class(PydanticPerson) is True
+        assert is_pydantic_model_class(PydanticAddress) is True
+        assert is_pydantic_model_class(Person) is False
+        assert is_pydantic_model_class(str) is False
+
+
+class TestStructFormatting:
+    """Test struct value formatting for SQL."""
+
+    def test_format_dataclass_struct_athena(self):
+        """Test formatting dataclass structs for Athena."""
+        person = Person(
+            name="John Doe",
+            age=30,
+            address=Address(street="123 Main St", city="New York", zip_code="10001"),
+        )
+
+        result = format_sql_value(person, Person, dialect="athena")
+        # Should format as CAST(ROW(...) AS ROW(...))
+        assert result.startswith("CAST(ROW(")
+        assert "'John Doe'" in result
+        assert "30" in result
+        assert "ROW(" in result  # Nested struct
+        assert "'123 Main St'" in result
+        assert "'New York'" in result
+        assert "'10001'" in result
+        assert "AS ROW(" in result  # Type cast
+        assert "name VARCHAR" in result
+        assert "age BIGINT" in result  # Athena uses BIGINT for integers
+
+    def test_format_dataclass_struct_trino(self):
+        """Test formatting dataclass structs for Trino."""
+        person = Person(
+            name="Jane Smith",
+            age=25,
+            address=Address(street="456 Oak Ave", city="Boston", zip_code="02101"),
+        )
+
+        result = format_sql_value(person, Person, dialect="trino")
+        # Should format as CAST(ROW(...) AS ROW(...))
+        assert result.startswith("CAST(ROW(")
+        assert "'Jane Smith'" in result
+        assert "25" in result
+        assert "AS ROW(" in result
+        assert "age BIGINT" in result  # Trino uses BIGINT
+
+    def test_format_pydantic_struct_athena(self):
+        """Test formatting Pydantic structs for Athena."""
+        person = PydanticPerson(
+            name="Bob Johnson",
+            age=45,
+            address=PydanticAddress(street="789 Pine Rd", city="Chicago", zip_code="60601"),
+        )
+
+        result = format_sql_value(person, PydanticPerson, dialect="athena")
+        # Should format as CAST(ROW(...) AS ROW(...))
+        assert result.startswith("CAST(ROW(")
+        assert "'Bob Johnson'" in result
+        assert "45" in result
+        assert "AS ROW(" in result
+
+    def test_format_null_struct_athena(self):
+        """Test formatting NULL struct for Athena."""
+        result = format_sql_value(None, Person, dialect="athena")
+        # Should format as CAST(NULL AS ROW(...))
+        assert result.startswith("CAST(NULL AS ROW(")
+        assert "name VARCHAR" in result
+        assert "age BIGINT" in result  # Athena uses BIGINT for integers
+        assert "address ROW(" in result  # Nested struct type
+
+    def test_format_null_struct_trino(self):
+        """Test formatting NULL struct for Trino."""
+        result = format_sql_value(None, Person, dialect="trino")
+        # Should format as CAST(NULL AS ROW(...))
+        assert result.startswith("CAST(NULL AS ROW(")
+        assert "name VARCHAR" in result
+        assert "age BIGINT" in result  # Trino uses BIGINT instead of INTEGER
+
+    def test_format_struct_unsupported_dialect(self):
+        """Test that struct formatting raises error for unsupported dialects."""
+        person = Person(
+            name="Test", age=20, address=Address(street="St", city="City", zip_code="12345")
+        )
+
+        with pytest.raises(NotImplementedError) as exc_info:
+            format_sql_value(person, Person, dialect="mysql")
+
+        assert "Struct type not yet supported for dialect: mysql" in str(exc_info.value)
+
+
+class TestStructTupleConversion:
+    """Test struct conversion from tuple format (as returned by Athena/Trino)."""
+
+    def test_convert_tuple_to_dataclass(self):
+        """Test converting tuple to dataclass struct."""
+        converter = BaseTypeConverter()
+
+        # Tuple representing Address('123 Main St', 'New York', '10001')
+        address_tuple = ("123 Main St", "New York", "10001")
+        result = converter.convert(address_tuple, Address)
+
+        assert isinstance(result, Address)
+        assert result.street == "123 Main St"
+        assert result.city == "New York"
+        assert result.zip_code == "10001"
+
+    def test_convert_nested_tuple_to_dataclass(self):
+        """Test converting nested tuple to dataclass with nested struct."""
+        converter = BaseTypeConverter()
+
+        # Tuple representing Person with nested Address
+        person_tuple = ("John Doe", 30, ("123 Main St", "New York", "10001"))
+        result = converter.convert(person_tuple, Person)
+
+        assert isinstance(result, Person)
+        assert result.name == "John Doe"
+        assert result.age == 30
+        assert isinstance(result.address, Address)
+        assert result.address.street == "123 Main St"
+        assert result.address.city == "New York"
+        assert result.address.zip_code == "10001"
+
+    def test_convert_tuple_to_pydantic(self):
+        """Test converting tuple to Pydantic model."""
+        converter = BaseTypeConverter()
+
+        # Tuple representing Address
+        address_tuple = ("456 Oak Ave", "Boston", "02101")
+        result = converter.convert(address_tuple, PydanticAddress)
+
+        assert isinstance(result, PydanticAddress)
+        assert result.street == "456 Oak Ave"
+        assert result.city == "Boston"
+        assert result.zip_code == "02101"
+
+    def test_convert_nested_tuple_to_pydantic(self):
+        """Test converting nested tuple to Pydantic model with nested struct."""
+        converter = BaseTypeConverter()
+
+        # Tuple representing Person with nested Address
+        person_tuple = ("Jane Smith", 25, ("789 Pine Rd", "Chicago", "60601"))
+        result = converter.convert(person_tuple, PydanticPerson)
+
+        assert isinstance(result, PydanticPerson)
+        assert result.name == "Jane Smith"
+        assert result.age == 25
+        assert isinstance(result.address, PydanticAddress)
+        assert result.address.street == "789 Pine Rd"
+        assert result.address.city == "Chicago"
+        assert result.address.zip_code == "60601"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION

  - Add struct type detection for dataclasses and Pydantic models
  - Implement struct to ROW type conversion with named fields
  - Support dot notation for accessing struct fields in SQL queries
  - Add struct value formatting with proper CAST syntax
  - Handle nested structs and NULL struct values
  - Add comprehensive unit and integration tests
  - Update documentation with struct type examples and usage
  - Refactor type conversion code to eliminate duplication
  - Added support for List[Struct]

  Struct types can now be used with Athena and Trino adapters by defining
  Python dataclasses or Pydantic models. SQL queries can access struct
  fields using dot notation (e.g., employee.address.city).