### PR TITLE
docs: document ClickHouse adapter + add to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,13 +108,17 @@ jobs:
           git push origin master --tags
 
       - name: Create GitHub Release
+        # NB: pass the PAT via `with: token:`, not the GITHUB_TOKEN env var.
+        # softprops/action-gh-release@v3 no longer honors the env fallback,
+        # and if it falls back to the default GITHUB_TOKEN the resulting
+        # `release: published` event is treated as "created by a workflow"
+        # and will NOT trigger publish.yml (GitHub loop protection).
         uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           tag_name: ${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}
           body_path: "CHANGELOG.md"
           draft: false
           prerelease: ${{ startsWith(steps.version.outputs.version, '0.') }}
           make_latest: ${{ !startsWith(steps.version.outputs.version, '0.') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,14 @@ jobs:
     uses: ./.github/workflows/duckdb-integration.yml
     secrets: inherit
 
+  clickhouse-integration:
+    name: ClickHouse Integration Tests
+    uses: ./.github/workflows/clickhouse-integration.yml
+    secrets: inherit
+
   release:
     name: Create release
-    needs: [unit-tests, athena-integration, bigquery-integration, redshift-integration, trino-integration, snowflake-integration, duckdb-integration]
+    needs: [unit-tests, athena-integration, bigquery-integration, redshift-integration, trino-integration, snowflake-integration, duckdb-integration, clickhouse-integration]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@
 title: SQL Testing Library
 description: >-
   Python SQL testing library for unit testing database queries with mock data injection.
-  Test BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB with pytest integration.
+  Test BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse with pytest integration.
   Perfect for data engineering teams building ETL pipelines, validating data transformations,
   and testing analytics queries. Type-safe results with Pydantic models.
 url: "https://gurmeetsaran.github.io"

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,6 +1,6 @@
 <!-- SEO Meta Tags -->
-<meta name="description" content="Python SQL testing library for unit testing BigQuery, Snowflake, Redshift, Athena, Trino & DuckDB queries with mock data. Pytest integration for data engineering, ETL pipelines, and analytics testing." />
-<meta name="keywords" content="python sql testing, sql unit testing, pytest sql, bigquery testing, snowflake testing, redshift testing, athena testing, trino testing, duckdb testing, data engineering testing, etl testing, sql mock data, database unit tests, python database testing, sql test framework, cloud database testing, data pipeline testing, sql query testing, analytics testing, data validation testing, sql testing library python, pytest database testing, bigquery unit tests, snowflake unit tests" />
+<meta name="description" content="Python SQL testing library for unit testing BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB & ClickHouse queries with mock data. Pytest integration for data engineering, ETL pipelines, and analytics testing." />
+<meta name="keywords" content="python sql testing, sql unit testing, pytest sql, bigquery testing, snowflake testing, redshift testing, athena testing, trino testing, duckdb testing, clickhouse testing, data engineering testing, etl testing, sql mock data, database unit tests, python database testing, sql test framework, cloud database testing, data pipeline testing, sql query testing, analytics testing, data validation testing, sql testing library python, pytest database testing, bigquery unit tests, snowflake unit tests, clickhouse unit tests" />
 <meta name="author" content="Gurmeet Saran and Kushal Thakkar" />
 <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}" />
 
@@ -41,7 +41,7 @@
         "price": "0",
         "priceCurrency": "USD"
       },
-      "description": "Python SQL testing library for unit testing database queries with mock data injection. Test BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB queries using pytest. Perfect for data engineering teams, ETL pipeline testing, and data validation.",
+      "description": "Python SQL testing library for unit testing database queries with mock data injection. Test BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse queries using pytest. Perfect for data engineering teams, ETL pipeline testing, and data validation.",
       "url": "{{ site.url }}{{ site.baseurl }}",
       "downloadUrl": "https://pypi.org/project/sql-testing-library/",
       "softwareVersion": "0.17.0",

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -2,13 +2,13 @@
 layout: default
 title: Database Adapters - Configuration Guide
 nav_order: 4
-description: "Configure SQL Testing Library for BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB. Database adapter setup and connection configuration guide."
+description: "Configure SQL Testing Library for BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse. Database adapter setup and connection configuration guide."
 ---
 
 # Database Adapters Configuration
 {: .no_toc }
 
-Configure database adapters for SQL unit testing with BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB.
+Configure database adapters for SQL unit testing with BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse.
 {: .fs-6 .fw-300 }
 
 ## Table of contents
@@ -33,6 +33,7 @@ The SQL Testing Library supports multiple database engines through adapters. Eac
 | Trino | `TrinoAdapter` | `trino` | Trino SQL |
 | Snowflake | `SnowflakeAdapter` | `snowflake-connector-python` | Snowflake SQL |
 | DuckDB | `DuckDBAdapter` | `duckdb` | DuckDB SQL |
+| ClickHouse | `ClickHouseAdapter` | `clickhouse-connect` | ClickHouse SQL |
 
 ## BigQuery Adapter
 
@@ -505,6 +506,185 @@ GROUP BY u.address.city
 - No need for indexing in test scenarios
 - Automatic query optimization and vectorized execution
 
+## ClickHouse Adapter
+
+### Installation
+
+```bash
+pip install sql-testing-library[clickhouse]
+```
+
+Uses the official `clickhouse-connect` HTTP client. For a fully local
+setup, start a server with Docker:
+
+```bash
+docker run -d --name clickhouse -p 8123:8123 \
+  -e CLICKHOUSE_SKIP_USER_SETUP=1 \
+  clickhouse/clickhouse-server:24.8-alpine
+```
+
+### Configuration
+
+```ini
+[sql_testing.clickhouse]
+host = localhost
+port = 8123          # HTTP port (8443 or 9440 for HTTPS)
+username = default
+password =
+database = default
+secure = false       # Set true for HTTPS connections (ClickHouse Cloud)
+```
+
+### Features
+
+- **HTTP Transport**: Uses `clickhouse-connect` against port 8123 (or 8443/9440 for TLS)
+- **Memory-Engine Tables**: Physical-mode temp tables use `ENGINE = Memory`
+  for zero-config, ephemeral storage
+- **Native Complex Types**: Full support for:
+  - Arrays: `Array(T)` for `List[T]`
+  - Maps: `Map(K, V)` for `Dict[K, V]`
+  - Structs: named `Tuple(field T, ...)` for dataclasses and Pydantic models
+- **Deeply Nested Types**: Nested arrays, arrays of tuples, arrays of arrays of tuples
+- **No Query Size Limit**: `get_query_size_limit()` returns `None`
+  (ClickHouse's default HTTP `max_query_size` is 256 KiB but is server-side configurable)
+
+### Nullability Rules
+
+ClickHouse forbids wrapping `Array`, `Map`, and `Tuple` in `Nullable(...)`.
+The adapter encodes the following rules so that NULLs round-trip cleanly:
+
+| Column type | Emitted CH type | NULL round-trip |
+|-------------|-----------------|-----------------|
+| Scalar (`str`, `int`, ...) | `Nullable(T)` | `None` |
+| `List[T]` (`Optional[List[T]]`) | `Array(T)` — never Nullable | Empty list `[]` (not `None`) |
+| `Dict[K, V]` (`Optional[Dict[K, V]]`) | `Map(K, V)` — never Nullable | Empty dict `{}` (not `None`) |
+| Struct (`Address`) | `Tuple(field Nullable(T), ...)` | All-None tuple → converter returns `None` for `Optional[Address]` |
+
+### Database Context
+
+ClickHouse uses a database-qualified name (default database is `default`):
+
+```python
+class MyMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "default"
+
+    def get_table_name(self) -> str:
+        return "users"
+```
+
+Queries reference tables as `default.users`.
+
+### Example
+
+```python
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Dict, List, Optional
+from pydantic import BaseModel
+from sql_testing_library import TestCase, sql_test
+from sql_testing_library._mock_table import BaseMockTable
+
+@dataclass
+class Address:
+    street: str
+    city: str
+    zip_code: str
+
+@dataclass
+class Customer:
+    customer_id: int
+    name: str
+    signup_date: date
+    lifetime_value: Optional[Decimal]
+    tags: List[str]
+    address: Address
+
+class CustomerResult(BaseModel):
+    customer_id: int
+    name: str
+    city: str
+    tag_count: int
+
+class CustomersMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "default"
+    def get_table_name(self) -> str:
+        return "customers"
+
+@sql_test(
+    adapter_type="clickhouse",
+    mock_tables=[CustomersMockTable([
+        Customer(
+            1, "Alice", date(2023, 1, 15), Decimal("1500.00"),
+            ["premium", "vip"],
+            Address("123 Main St", "New York", "10001"),
+        ),
+    ])],
+    result_class=CustomerResult,
+)
+def test_customer_query():
+    return TestCase(
+        query="""
+            SELECT
+                customer_id,
+                name,
+                tupleElement(address, 'city') AS city,
+                length(tags) AS tag_count
+            FROM customers
+        """,
+        default_namespace="default",
+    )
+```
+
+### SQL Examples
+
+```sql
+-- Named-tuple field access. sqlglot's clickhouse dialect rewrites
+-- `x.field` and drops quoting, so prefer tupleElement(...) explicitly.
+SELECT
+    tupleElement(address, 'street') AS street,
+    tupleElement(address, 'city')   AS city
+FROM customers
+
+-- Array operations (1-based indexing, length() for size, has() for contains)
+SELECT
+    name,
+    length(tags)        AS tag_count,
+    tags[1]             AS first_tag,
+    has(tags, 'premium') AS is_premium
+FROM customers
+
+-- Map operations (default value for missing keys; use mapContains to preserve NULL)
+SELECT
+    name,
+    metadata['role']    AS role_or_default,
+    if(mapContains(metadata, 'role'), metadata['role'], NULL) AS role_or_null
+FROM customers
+
+-- Unnest an array (ARRAY JOIN, not UNNEST)
+SELECT id, tag
+FROM customers
+ARRAY JOIN tags AS tag
+
+-- Higher-order array functions (arraySum, arrayCount, arrayMap, arrayFilter)
+SELECT
+    id,
+    arraySum(p -> assumeNotNull(tupleElement(p, 'budget')), projects) AS total_budget,
+    arrayCount(p -> assumeNotNull(tupleElement(p, 'is_active')), projects) AS active_count
+FROM developers
+```
+
+### Testing Tips
+
+- The `clickhouse-connect` client is **not thread-safe**. Multi-table physical-mode
+  tests should set `parallel_table_creation=False` on the `@sql_test` decorator.
+- `Decimal(38, 9)` columns come back with full 9-digit scale (e.g., `Decimal('1.500000000')`).
+  Python's `Decimal` equality is by value, so `Decimal('1.5') == Decimal('1.500000000')` still holds.
+- The `Memory` engine is fastest for tests but data is lost on server restart —
+  which is exactly what we want for test isolation.
+
 ## Choosing an Adapter
 
 ### Default Adapter Configuration
@@ -550,40 +730,41 @@ adapter = redshift  # Default for all tests
 
 ### Primitive Types
 
-| Type | BigQuery | Athena | Redshift | Trino | Snowflake | DuckDB |
-|------|----------|---------|----------|-------|-----------|---------|
-| String | ✅ STRING | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR |
-| Integer | ✅ INT64 | ✅ BIGINT | ✅ INTEGER | ✅ BIGINT | ✅ NUMBER | ✅ BIGINT |
-| Float | ✅ FLOAT64 | ✅ DOUBLE | ✅ REAL | ✅ DOUBLE | ✅ FLOAT | ✅ DOUBLE |
-| Boolean | ✅ BOOL | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN |
-| Date | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE |
-| Datetime | ✅ DATETIME | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP |
-| Decimal | ✅ NUMERIC | ✅ DECIMAL | ✅ DECIMAL | ✅ DECIMAL | ✅ NUMBER | ✅ DECIMAL |
+| Type | BigQuery | Athena | Redshift | Trino | Snowflake | DuckDB | ClickHouse |
+|------|----------|---------|----------|-------|-----------|---------|-----------|
+| String | ✅ STRING | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR | ✅ VARCHAR | ✅ String |
+| Integer | ✅ INT64 | ✅ BIGINT | ✅ INTEGER | ✅ BIGINT | ✅ NUMBER | ✅ BIGINT | ✅ Int64 |
+| Float | ✅ FLOAT64 | ✅ DOUBLE | ✅ REAL | ✅ DOUBLE | ✅ FLOAT | ✅ DOUBLE | ✅ Float64 |
+| Boolean | ✅ BOOL | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN | ✅ BOOLEAN | ✅ Bool |
+| Date | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE | ✅ DATE | ✅ Date |
+| Datetime | ✅ DATETIME | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ TIMESTAMP | ✅ DateTime64(6) |
+| Decimal | ✅ NUMERIC | ✅ DECIMAL | ✅ DECIMAL | ✅ DECIMAL | ✅ NUMBER | ✅ DECIMAL | ✅ Decimal(38, 9) |
 
 ### Complex Types
 
-| Type | Python Type | BigQuery | Athena | Redshift | Trino | Snowflake | DuckDB |
-|------|-------------|----------|---------|----------|-------|-----------|---------|
-| String Array | `List[str]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
-| Int Array | `List[int]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
-| Decimal Array | `List[Decimal]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
-| String Map | `Dict[str, str]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT | ✅ MAP |
-| Int Map | `Dict[str, int]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT | ✅ MAP |
-| Mixed Map | `Dict[K, V]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT | ✅ MAP |
-| Struct | `dataclass` | ✅ STRUCT | ✅ ROW | ✅ SUPER | ✅ ROW | ✅ OBJECT | ✅ STRUCT |
-| Struct | `Pydantic model` | ✅ STRUCT | ✅ ROW | ✅ SUPER | ✅ ROW | ✅ OBJECT | ✅ STRUCT |
-| **Nested Arrays** | `List[List[T]]` | ❌ | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
-| **Arrays of Structs** | `List[dataclass]` | ✅ ARRAY | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
-| **3D Arrays** | `List[List[List[T]]]` | ❌ | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
-| **Arrays of Arrays of Structs** | `List[List[dataclass]]` | ❌ | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST |
+| Type | Python Type | BigQuery | Athena | Redshift | Trino | Snowflake | DuckDB | ClickHouse |
+|------|-------------|----------|---------|----------|-------|-----------|---------|-----------|
+| String Array | `List[str]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
+| Int Array | `List[int]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
+| Decimal Array | `List[Decimal]` | ✅ ARRAY | ✅ ARRAY | ✅ JSON | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
+| String Map | `Dict[str, str]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT | ✅ MAP | ✅ Map |
+| Int Map | `Dict[str, int]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT | ✅ MAP | ✅ Map |
+| Mixed Map | `Dict[K, V]` | ✅ JSON | ✅ MAP | ✅ SUPER | ✅ MAP | ✅ VARIANT | ✅ MAP | ✅ Map |
+| Struct | `dataclass` | ✅ STRUCT | ✅ ROW | ✅ SUPER | ✅ ROW | ✅ OBJECT | ✅ STRUCT | ✅ Tuple |
+| Struct | `Pydantic model` | ✅ STRUCT | ✅ ROW | ✅ SUPER | ✅ ROW | ✅ OBJECT | ✅ STRUCT | ✅ Tuple |
+| **Nested Arrays** | `List[List[T]]` | ❌ | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
+| **Arrays of Structs** | `List[dataclass]` | ✅ ARRAY | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
+| **3D Arrays** | `List[List[List[T]]]` | ❌ | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
+| **Arrays of Arrays of Structs** | `List[List[dataclass]]` | ❌ | ✅ ARRAY | ✅ SUPER | ✅ ARRAY | ✅ ARRAY | ✅ LIST | ✅ Array |
 
 **Legend:**
 - ✅ = Fully supported with comprehensive tests
 - ❌ = Not supported (database limitation)
 
 **Deeply Nested Types Support:**
-- **All Major Adapters**: Full support for deeply nested complex types including nested arrays (2D, 3D+), arrays of structs, and arrays of arrays of structs across Athena, Trino, DuckDB, Redshift, and Snowflake. See `tests/integration/test_deeply_nested_types_integration.py` for comprehensive examples with 20 passing tests.
+- **All Major Adapters**: Full support for deeply nested complex types including nested arrays (2D, 3D+), arrays of structs, and arrays of arrays of structs across Athena, Trino, DuckDB, Redshift, Snowflake, and ClickHouse. See `tests/integration/test_deeply_nested_types_integration.py` for comprehensive examples.
 - **BigQuery**: Does not support nested arrays (arrays of arrays) - this is a database limitation in BigQuery's type system. Struct types and arrays of structs work fine.
+- **ClickHouse**: `Array`, `Map`, and `Tuple` types cannot themselves be `Nullable` (a CH restriction), so NULL arrays/maps round-trip as empty containers (`[]` / `{}`). Struct fields are wrapped in `Nullable(...)` so a fully-NULL struct is representable as `tuple(NULL, ...)` and deserialized back to `None` when the Python target is `Optional[Struct]`.
 
 ## Adapter-Specific SQL
 
@@ -772,6 +953,38 @@ SELECT
 FROM users u
 ```
 
+### ClickHouse
+
+```sql
+-- Arrays: 1-based indexing, length() for size, has() for contains,
+-- ARRAY JOIN for unnesting
+SELECT length(tags), tags[1], has(tags, 'premium') FROM customers
+SELECT id, tag FROM customers ARRAY JOIN tags AS tag
+
+-- Named-tuple field access: prefer tupleElement(...) explicitly since
+-- sqlglot's clickhouse dialect rewrites `x.field` and drops quoting
+SELECT tupleElement(address, 'city') FROM customers
+
+-- Map access. Missing keys return the value type's default (0 / '')
+-- rather than NULL, so use mapContains(...) when NULL semantics matter
+SELECT
+    metadata['role'] AS role_or_default,
+    if(mapContains(metadata, 'role'), metadata['role'], NULL) AS role_or_null
+FROM customers
+
+-- Higher-order array functions (arraySum, arrayCount, arrayMap, arrayFilter)
+-- Note: Tuple fields are Nullable(...), so unwrap with assumeNotNull
+-- before feeding into aggregations that don't accept Nullable numerics
+SELECT
+    id,
+    arraySum(p -> assumeNotNull(tupleElement(p, 'budget')), projects) AS total,
+    arrayCount(p -> assumeNotNull(tupleElement(p, 'is_active')), projects) AS active
+FROM developers
+
+-- Date/datetime literals
+SELECT toDate('2023-01-15'), toDateTime64('2023-01-15 10:30:00.123456', 6)
+```
+
 ## Troubleshooting
 
 ### Connection Issues
@@ -782,6 +995,7 @@ FROM users u
 4. **Trino**: Ensure correct authentication method
 5. **Snowflake**: Verify account identifier format
 6. **DuckDB**: Check file permissions for file-based databases
+7. **ClickHouse**: Verify HTTP port (`8123`, or `8443`/`9440` for HTTPS with `secure = true`); confirm the `default` user's password (self-hosted images that don't set `CLICKHOUSE_SKIP_USER_SETUP=1` will generate a random one on first boot)
 
 ### Query Failures
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,13 +2,13 @@
 layout: default
 title: Examples - SQL Unit Testing with Python
 nav_order: 3
-description: "Real-world examples of SQL unit testing with Python. Learn how to test BigQuery, Snowflake, Redshift, Athena queries with mock data using pytest."
+description: "Real-world examples of SQL unit testing with Python. Learn how to test BigQuery, Snowflake, Redshift, Athena, and ClickHouse queries with mock data using pytest."
 ---
 
 # SQL Testing Examples
 {: .no_toc }
 
-Real-world examples of SQL unit testing for BigQuery, Snowflake, Athena, and other cloud databases using Python and pytest.
+Real-world examples of SQL unit testing for BigQuery, Snowflake, Athena, ClickHouse, and other cloud databases using Python and pytest.
 {: .fs-6 .fw-300 }
 
 ## Table of contents
@@ -1004,6 +1004,132 @@ def test_duckdb_map_operations():
         default_namespace="analytics_db"
     )
 ```
+
+### ClickHouse-Specific Features
+
+ClickHouse uses `Array(T)`, `Map(K, V)`, and named `Tuple(field T, ...)`
+for complex types. Its SQL syntax diverges from ANSI in a few common
+ways: `length()` instead of `CARDINALITY`, `has()` instead of `CONTAINS`,
+`tupleElement(x, 'field')` for named-tuple field access (sqlglot
+mangles bare `x.field` for CH), and `ARRAY JOIN` instead of `UNNEST`.
+
+```python
+from dataclasses import dataclass
+from typing import Dict, List
+from decimal import Decimal
+from datetime import date
+
+@dataclass
+class CustomerAddress:
+    street: str
+    city: str
+    zip_code: str
+
+@dataclass
+class Customer:
+    customer_id: int
+    name: str
+    signup_date: date
+    tags: List[str]
+    metadata: Dict[str, str]
+    address: CustomerAddress
+
+class CustomersMockTable(BaseMockTable):
+    def get_database_name(self) -> str:
+        return "default"
+    def get_table_name(self) -> str:
+        return "customers"
+
+class CustomerSummary(BaseModel):
+    customer_id: int
+    name: str
+    city: str
+    tag_count: int
+    is_premium: bool
+    role: Optional[str]
+
+# ClickHouse Array + Map + Tuple field access
+@sql_test(
+    adapter_type="clickhouse",
+    mock_tables=[
+        CustomersMockTable([
+            Customer(
+                1, "Alice", date(2023, 1, 15),
+                tags=["premium", "vip"],
+                metadata={"role": "admin", "region": "us-east"},
+                address=CustomerAddress("123 Main St", "New York", "10001"),
+            ),
+            Customer(
+                2, "Bob", date(2023, 2, 20),
+                tags=["standard"],
+                metadata={"region": "us-west"},
+                address=CustomerAddress("456 Oak Ave", "San Francisco", "94105"),
+            ),
+        ])
+    ],
+    result_class=CustomerSummary,
+)
+def test_clickhouse_customer_summary():
+    return TestCase(
+        query="""
+            SELECT
+                customer_id,
+                name,
+                tupleElement(address, 'city') AS city,
+                length(tags) AS tag_count,
+                has(tags, 'premium') AS is_premium,
+                if(mapContains(metadata, 'role'),
+                   metadata['role'],
+                   NULL) AS role
+            FROM customers
+            ORDER BY customer_id
+        """,
+        default_namespace="default",
+    )
+
+# ClickHouse ARRAY JOIN (equivalent to UNNEST/CROSS JOIN in ANSI SQL)
+class UnnestedTag(BaseModel):
+    customer_id: int
+    tag: str
+
+@sql_test(
+    adapter_type="clickhouse",
+    mock_tables=[
+        CustomersMockTable([
+            Customer(
+                1, "Alice", date(2023, 1, 15),
+                tags=["premium", "vip"],
+                metadata={},
+                address=CustomerAddress("", "", ""),
+            ),
+        ])
+    ],
+    result_class=UnnestedTag,
+)
+def test_clickhouse_array_join():
+    return TestCase(
+        query="""
+            SELECT customer_id, tag
+            FROM customers
+            ARRAY JOIN tags AS tag
+            ORDER BY customer_id, tag
+        """,
+        default_namespace="default",
+    )
+```
+
+**ClickHouse nullability quirks:**
+- `Array` and `Map` cannot be `Nullable`, so `None` optional arrays/maps come back
+  as empty containers (`[]` / `{}`), never `None`.
+- `Tuple` also cannot be `Nullable`, but its scalar fields are wrapped in `Nullable(...)`
+  so a NULL struct becomes `tuple(NULL, NULL, ...)` — the type converter recognizes
+  an all-None tuple as `None` when the Python target is `Optional[Struct]`.
+- `Decimal(38, 9)` columns return values with the full 9-digit scale
+  (`Decimal('1.500000000')`). Python `Decimal` compares by value, so
+  `Decimal('1.5') == Decimal('1.500000000')` still holds.
+- Multi-mock-table tests in physical-tables mode should pass
+  `parallel_table_creation=False` because `clickhouse-connect` clients
+  are not thread-safe.
 
 ## Testing Patterns
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 layout: default
 title: Getting Started - Installation & Setup
 nav_order: 2
-description: "Install and configure SQL Testing Library for Python. Setup pytest integration for BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB unit testing."
+description: "Install and configure SQL Testing Library for Python. Setup pytest integration for BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse unit testing."
 ---
 
 # Getting Started with SQL Testing Library
@@ -43,6 +43,9 @@ pip install sql-testing-library[snowflake]
 
 # For DuckDB
 pip install sql-testing-library[duckdb]
+
+# For ClickHouse
+pip install sql-testing-library[clickhouse]
 ```
 
 ### Install with all database adapters
@@ -61,7 +64,7 @@ git clone https://github.com/gurmeetsaran/sqltesting.git
 cd sqltesting
 
 # Install with poetry
-poetry install --with bigquery,athena,redshift,trino,snowflake,dev
+poetry install --with bigquery,athena,redshift,trino,snowflake,duckdb,clickhouse,dev
 ```
 
 ## Configuration
@@ -72,7 +75,7 @@ The library uses pytest configuration files to manage database connections. Crea
 
 ```ini
 [sql_testing]
-adapter = bigquery  # Choose: bigquery, athena, redshift, trino, snowflake, or duckdb
+adapter = bigquery  # Choose: bigquery, athena, redshift, trino, snowflake, duckdb, or clickhouse
 ```
 
 ### Database-specific configuration
@@ -170,6 +173,40 @@ database = :memory:  # Use in-memory database (default, fastest for testing)
 - Excellent performance for analytical queries
 - Full support for complex types (arrays, structs, maps)
 - Perfect for local development and CI/CD testing
+
+#### ClickHouse
+
+ClickHouse is a column-oriented analytics database. Point the adapter at
+any HTTP(S) endpoint — self-hosted, Docker, or ClickHouse Cloud:
+
+```ini
+[sql_testing.clickhouse]
+host = localhost
+port = 8123          # HTTP port (8443 or 9440 for HTTPS)
+username = default
+password =
+database = default
+secure = false       # Set true for HTTPS (ClickHouse Cloud)
+```
+
+**ClickHouse Configuration Options:**
+
+- **`host`** *(required)*: Server hostname or IP
+- **`port`**: HTTP port (default `8123`, use `8443` / `9440` for HTTPS)
+- **`username`** / **`password`**: Server credentials (defaults to `default`, empty)
+- **`database`**: Default database (defaults to `default`)
+- **`secure`**: `true` for HTTPS connections (ClickHouse Cloud)
+
+**Local Docker quickstart:**
+
+```bash
+docker run -d --name clickhouse -p 8123:8123 \
+  -e CLICKHOUSE_SKIP_USER_SETUP=1 \
+  clickhouse/clickhouse-server:24.8-alpine
+```
+
+The `CLICKHOUSE_SKIP_USER_SETUP=1` env var keeps the `default` user
+password-free (newer images generate a random password by default).
 
 ## Writing Your First Test
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 layout: default
 title: Python SQL Unit Testing with Pytest
 nav_order: 1
-description: "Python SQL testing library for unit testing database queries with mock data. Test BigQuery, Snowflake, Redshift, Athena, Trino & DuckDB with pytest. Perfect for data engineering and ETL pipeline testing."
+description: "Python SQL testing library for unit testing database queries with mock data. Test BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB & ClickHouse with pytest. Perfect for data engineering and ETL pipeline testing."
 permalink: /
 ---
 
 # SQL Testing Library for Python
 {: .fs-9 }
 
-Unit test SQL queries with mock data injection for BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB. Pytest integration for data engineering and ETL testing.
+Unit test SQL queries with mock data injection for BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse. Pytest integration for data engineering and ETL testing.
 {: .fs-6 .fw-300 }
 
 [Get started now](getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 } [View on GitHub](https://github.com/gurmeetsaran/sqltesting){: .btn .fs-5 .mb-4 .mb-md-0 }
@@ -18,7 +18,7 @@ Unit test SQL queries with mock data injection for BigQuery, Snowflake, Redshift
 
 ## 🎯 Why Use SQL Testing Library for Python?
 
-**SQL unit testing** in data engineering can be challenging, especially when working with cloud databases like **BigQuery, Snowflake, Redshift, and Athena**. This **Python SQL testing framework** addresses critical pain points:
+**SQL unit testing** in data engineering can be challenging, especially when working with cloud databases like **BigQuery, Snowflake, Redshift, Athena, and ClickHouse**. This **Python SQL testing framework** addresses critical pain points:
 
 - **Fragile Integration Tests**: Traditional SQL tests that depend on live data break when data changes, causing flaky CI/CD pipelines
 - **Slow Feedback Loops**: Running database tests against full datasets takes too long for continuous integration
@@ -33,7 +33,7 @@ Whether you're building **ETL pipelines**, validating **data transformations**, 
 ## ✨ Key Features
 
 ### 🚀 Multi-Database Support
-Test your SQL queries across BigQuery, Athena, Redshift, Trino, Snowflake, and DuckDB with a unified API.
+Test your SQL queries across BigQuery, Athena, Redshift, Trino, Snowflake, DuckDB, and ClickHouse with a unified API.
 
 ### 🎯 Type-Safe Testing
 Use Python dataclasses and Pydantic models for type-safe test data and results.
@@ -101,6 +101,7 @@ def test_user_query():
 | **Trino** | ✅ | ✅ | ~16MB |
 | **Snowflake** | ✅ | ✅ | 1MB |
 | **DuckDB** | ✅ | ✅ | No limit |
+| **ClickHouse** | ✅ | ✅ | No hard limit |
 
 ### Data Types Support
 
@@ -115,11 +116,11 @@ def test_user_query():
 - Arrays
 - Map/Dict types (Dict[K, V])
 - Optional/Nullable types
-- Struct/Record types (Athena/Trino/BigQuery - using dataclasses or Pydantic models)
+- Struct/Record types (Athena/Trino/BigQuery/DuckDB/ClickHouse - using dataclasses or Pydantic models; ClickHouse uses native named `Tuple`)
 
 ❌ **Not Yet Supported**:
 - Struct/Record types for Redshift and Snowflake
-- Nested Arrays (arrays of arrays)
+- Nested Arrays (arrays of arrays) on BigQuery
 
 ## 📚 Documentation
 
@@ -170,6 +171,7 @@ pip install sql-testing-library[redshift]
 pip install sql-testing-library[trino]
 pip install sql-testing-library[snowflake]
 pip install sql-testing-library[duckdb]
+pip install sql-testing-library[clickhouse]
 
 # Or install with all database adapters
 pip install sql-testing-library[all]
@@ -218,7 +220,7 @@ Built with ❤️ by the data engineering community. Special thanks to all [cont
 
 ### How do I unit test SQL queries in Python?
 
-Use SQL Testing Library with pytest to write unit tests for SQL queries. The library injects mock data via CTEs or temporary tables, allowing you to test query logic without accessing real databases. Perfect for testing BigQuery, Snowflake, Redshift, Athena, Trino, and DuckDB queries.
+Use SQL Testing Library with pytest to write unit tests for SQL queries. The library injects mock data via CTEs or temporary tables, allowing you to test query logic without accessing real databases. Perfect for testing BigQuery, Snowflake, Redshift, Athena, Trino, DuckDB, and ClickHouse queries.
 
 ### Can I test BigQuery SQL queries without a BigQuery account?
 


### PR DESCRIPTION
## Summary

Follow-up to the ClickHouse adapter merge (#157) — adds ClickHouse to the release workflow and the docs / GitHub Pages site.

### Release workflow
- `.github/workflows/release.yml`: new `clickhouse-integration` job, added to the release job's `needs:` list so a release now requires the CH integration suite to pass alongside all other adapters.

### GitHub Pages docs
- `docs/index.md`: landing page — CH in the supported-databases table, features/type-support text, install snippets, FAQ.
- `docs/adapters.md`: full new **ClickHouse Adapter** section covering install (with a Docker quickstart), config, features, the CH nullability rules (why `Array`/`Map`/`Tuple` can't be `Nullable` and how the adapter works around it), DB context, a runnable example, per-operation SQL examples, and testing tips (thread-safety, Decimal precision). Also new columns in the primitive/complex type-support tables and a **ClickHouse** subsection under Adapter-Specific SQL.
- `docs/getting-started.md`: new **ClickHouse** subsection with a Docker quickstart, plus updated install / poetry commands.
- `docs/examples.md`: full new **ClickHouse-Specific Features** section covering `tupleElement` for named-tuple field access, `mapContains` for NULL-preserving map access, `ARRAY JOIN` for unnesting, and the CH nullability quirks.
- `docs/_config.yml`, `docs/_includes/head_custom.html`: site description, keywords, and JSON-LD structured data all include ClickHouse now.

## Test plan

- [x] Docs render locally (Jekyll)
- [ ] Release workflow's new `clickhouse-integration` node shows up on the next dispatched release run
- [ ] GitHub Pages rebuild picks up the changes after merge